### PR TITLE
Add validation for new passwordPath for TypeCA

### DIFF
--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -88,6 +88,87 @@ func TestConfigurationStructLevelValidatorPublicKeySSH(t *testing.T) {
 	}
 }
 
+func TestConfigurationStructLevelValidatorPKCS12(t *testing.T) {
+	alias := &AliasConfig{
+		Alias:        "fdsaAlias",
+		Type:         TypeCA,
+		Algorithm:    "ECDSAWithSHA256",
+		CommonName:   "forgerock",
+		PasswordPath: []string{"asdfSecret", "fdsaPassword"},
+	}
+	passwordKey := &KeyConfig{
+		Name:   "fdsaPassword",
+		Type:   TypePassword,
+		Length: 32,
+	}
+	key := &KeyConfig{
+		Name: "fdsaKey",
+		Type: TypePKCS12,
+	}
+	config := getConfig()
+	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
+	config.Secrets[0].Keys = append(config.Secrets[0].Keys, passwordKey)
+	validate := validator.New()
+	validate.RegisterStructValidation(ConfigurationStructLevelValidator, Configuration{})
+	// missing aliasConfigs
+	err := validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	// valid
+	key.AliasConfigs = append(key.AliasConfigs, alias)
+	err = validate.Struct(config)
+	if err != nil {
+		t.Errorf("Expected no error, got: %+v", err)
+	}
+}
+
+func TestConfigurationStructLevelValidatorCA(t *testing.T) {
+	alias := &AliasConfig{
+		Alias:      "fdsaAlias",
+		Type:       TypeCA,
+		Algorithm:  "ECDSAWithSHA256",
+		CommonName: "forgerock",
+	}
+	key := &KeyConfig{
+		Name:         "fdsaKey",
+		Type:         TypePKCS12,
+		AliasConfigs: []*AliasConfig{alias},
+	}
+	config := getConfig()
+	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
+	validate := validator.New()
+	validate.RegisterStructValidation(ConfigurationStructLevelValidator, Configuration{})
+	// missing passwordPath
+	err := validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	// passwordPath points to non-existent secret/key
+	config.Secrets[0].Keys[0].AliasConfigs[0].PasswordPath = []string{"mySecret1", "deployment-ca.pin"}
+	err = validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	// valid
+	secret := &SecretConfig{
+		Name:      "mySecret1",
+		Namespace: "default",
+		Keys: []*KeyConfig{
+			&KeyConfig{
+				Name:   "deployment-ca.pin",
+				Type:   TypePassword,
+				Length: 32,
+			},
+		},
+	}
+	config.Secrets = append(config.Secrets, secret)
+	err = validate.Struct(config)
+	if err != nil {
+		t.Errorf("Expected no error, got: %+v", err)
+	}
+}
+
 func getConfig() *Configuration {
 	return &Configuration{
 		AppConfig: AppConfig{

--- a/secretsConfig.yaml
+++ b/secretsConfig.yaml
@@ -44,6 +44,7 @@ secrets:
       type: ca
       algorithm: ECDSAWithSHA256
       commonName: ForgeRock.com
+      passwordPath: ["ds", "deployment-ca.pin"]
     - alias: ssl-key-pair
       type: keyPair  # hmacKey, aesKey
       algorithm: ECDSAWithSHA256


### PR DESCRIPTION
As the title says. Simon updated me that we would need a passwordPath for the deployment key for CAs in keystores.

All tests passing.