### PR TITLE
Improve passwordPath testing, remove duplicated nodes

### DIFF
--- a/pkg/memorystore/memorystore.go
+++ b/pkg/memorystore/memorystore.go
@@ -35,6 +35,8 @@ func rangeOverSecrets(secretsConfig []*types.SecretConfig, nodes []*types.Node, 
 			for _, aliasConfig := range keyConfig.AliasConfigs {
 				// key alias signedWithPath
 				nodes = fn(aliasConfig.SignedWithPath, []string{secretConfig.Name, keyConfig.Name, aliasConfig.Alias}, secretConfig, keyConfig, aliasConfig, nodes)
+				// key passwordPath
+				nodes = fn(aliasConfig.PasswordPath, []string{secretConfig.Name, keyConfig.Name, aliasConfig.Alias}, secretConfig, keyConfig, aliasConfig, nodes)
 			}
 		}
 	}
@@ -75,9 +77,16 @@ func addParentsAndChildren(parent, path []string, secretConfig *types.SecretConf
 		// find the parent node(s) of the path
 		for _, parentNode := range nodes {
 			if Equal(parentNode.Path, parent) {
+			parentNodes:
 				// find the node of the path
 				for _, node := range nodes {
 					if Equal(node.Path, path) {
+						// make sure it doesn't already exist
+						for _, n := range node.Parents {
+							if Equal(n.Path, parentNode.Path) {
+								continue parentNodes
+							}
+						}
 						node.Parents = append(node.Parents, parentNode)
 						parentNode.Children = append(parentNode.Children, node)
 						break

--- a/pkg/memorystore/memorystore_test.go
+++ b/pkg/memorystore/memorystore_test.go
@@ -17,11 +17,11 @@ func TestGetDependencyNodes(t *testing.T) {
 	if !reflect.DeepEqual(nodes, expectedNodes) {
 		expectedN := ""
 		for _, s := range expectedNodes {
-			expectedN = fmt.Sprintf("%v\n%v", expectedN, s)
+			expectedN = fmt.Sprintf("%v\n%p: %v", expectedN, s, s)
 		}
 		gotN := ""
 		for _, s := range nodes {
-			gotN = fmt.Sprintf("%v\n%v", gotN, s)
+			gotN = fmt.Sprintf("%v\n%p: %v", gotN, s, s)
 		}
 		t.Errorf("Expected \n%s, got \n%s", expectedN, gotN)
 	}
@@ -34,11 +34,11 @@ func TestGetDependencyNodes(t *testing.T) {
 	if !reflect.DeepEqual(nodes, expectedNodes) {
 		expectedN := ""
 		for _, s := range expectedNodes {
-			expectedN = fmt.Sprintf("%v\n%v", expectedN, s)
+			expectedN = fmt.Sprintf("%v\n%p: %v", expectedN, s, s)
 		}
 		gotN := ""
 		for _, s := range nodes {
-			gotN = fmt.Sprintf("%v\n%v", gotN, s)
+			gotN = fmt.Sprintf("%v\n%p: %v", gotN, s, s)
 		}
 		t.Errorf("Expected \n%s, got \n%s", expectedN, gotN)
 	}


### PR DESCRIPTION
PasswordPath was needed for deployment key CA, this adds tests for it to the other half of the example test scenarios.

Remove duplicated parent and child nodes in dependency tree when two or more paths lead to the same node.