### PR TITLE
StorePassPath and KeyPassPath should parent all aliases, refactor

### DIFF
--- a/pkg/memorystore/test/helpers.go
+++ b/pkg/memorystore/test/helpers.go
@@ -165,20 +165,20 @@ func GetExpectedNodesConfiguration1() ([]*types.Node, *types.Configuration) {
 	dsKeystore.Children = nil
 	nodes = append(nodes, dsKeystore)
 	// dsKeystoreDeploymentCa
-	dsKeystoreDeploymentCa.Parents = []*types.Node{dsDeploymentCAPin}
+	dsKeystoreDeploymentCa.Parents = []*types.Node{dsKeystorePin, dsDeploymentCAPin}
 	dsKeystoreDeploymentCa.Children = []*types.Node{dsKeystore, dsKeystoreSslKeyPair}
 	nodes = append(nodes, dsKeystoreDeploymentCa)
 	// dsKeystoreMasterKey
-	dsKeystoreMasterKey.Parents = []*types.Node{dsKeystoreSslKeyPair}
+	dsKeystoreMasterKey.Parents = []*types.Node{dsKeystorePin, dsKeystoreSslKeyPair}
 	dsKeystoreMasterKey.Children = []*types.Node{dsKeystore}
 	nodes = append(nodes, dsKeystoreMasterKey)
 	// dsKeystoreSslKeyPair
-	dsKeystoreSslKeyPair.Parents = []*types.Node{dsKeystoreDeploymentCa}
+	dsKeystoreSslKeyPair.Parents = []*types.Node{dsKeystorePin, dsKeystoreDeploymentCa}
 	dsKeystoreSslKeyPair.Children = []*types.Node{dsKeystore, dsKeystoreMasterKey}
 	nodes = append(nodes, dsKeystoreSslKeyPair)
 	// dsKeystorePin
 	dsKeystorePin.Parents = nil
-	dsKeystorePin.Children = []*types.Node{dsKeystore}
+	dsKeystorePin.Children = []*types.Node{dsKeystoreDeploymentCa, dsKeystoreMasterKey, dsKeystoreSslKeyPair, dsKeystore}
 	nodes = append(nodes, dsKeystorePin)
 	// dsDeploymentCAPin
 	dsDeploymentCAPin.Parents = nil
@@ -368,28 +368,28 @@ func GetExpectedNodesConfiguration2() ([]*types.Node, *types.Configuration) {
 	secretCkeyC.Children = nil
 	nodes = append(nodes, secretCkeyC)
 	// secretCkeyCalias1
-	secretCkeyCalias1.Parents = nil
-	secretCkeyCalias1.Children = []*types.Node{secretCkeyC, secretBkeyB, secretCkeyCalias2}
+	secretCkeyCalias1.Parents = []*types.Node{secretCkeyD, secretDkeyD}
+	secretCkeyCalias1.Children = []*types.Node{secretBkeyB, secretCkeyC, secretCkeyCalias2}
 	nodes = append(nodes, secretCkeyCalias1)
 	// secretCkeyCalias2
-	secretCkeyCalias2.Parents = []*types.Node{secretCkeyCalias1}
+	secretCkeyCalias2.Parents = []*types.Node{secretCkeyD, secretDkeyD, secretCkeyCalias1}
 	secretCkeyCalias2.Children = []*types.Node{secretCkeyC, secretCkeyCalias3}
 	nodes = append(nodes, secretCkeyCalias2)
 	// secretCkeyCalias3
-	secretCkeyCalias3.Parents = []*types.Node{secretCkeyCalias2}
+	secretCkeyCalias3.Parents = []*types.Node{secretCkeyD, secretDkeyD, secretCkeyCalias2}
 	secretCkeyCalias3.Children = []*types.Node{secretCkeyC}
 	nodes = append(nodes, secretCkeyCalias3)
 	// secretCkeyCalias4
-	secretCkeyCalias4.Parents = []*types.Node{secretCkeyD}
+	secretCkeyCalias4.Parents = []*types.Node{secretCkeyD, secretDkeyD}
 	secretCkeyCalias4.Children = []*types.Node{secretCkeyC}
 	nodes = append(nodes, secretCkeyCalias4)
 	// secretCkeyD
 	secretCkeyD.Parents = nil
-	secretCkeyD.Children = []*types.Node{secretCkeyC, secretCkeyCalias4}
+	secretCkeyD.Children = []*types.Node{secretCkeyCalias1, secretCkeyCalias2, secretCkeyCalias3, secretCkeyCalias4, secretCkeyC}
 	nodes = append(nodes, secretCkeyD)
 	// secretDkeyD
 	secretDkeyD.Parents = []*types.Node{secretEkeyE}
-	secretDkeyD.Children = []*types.Node{secretCkeyC}
+	secretDkeyD.Children = []*types.Node{secretCkeyCalias1, secretCkeyCalias2, secretCkeyCalias3, secretCkeyCalias4, secretCkeyC}
 	nodes = append(nodes, secretDkeyD)
 	// secretEkeyE
 	secretEkeyE.Parents = nil

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -92,8 +92,6 @@ func TestConfigurationStructLevelValidatorPKCS12(t *testing.T) {
 	alias := &AliasConfig{
 		Alias:        "fdsaAlias",
 		Type:         TypeCA,
-		Algorithm:    "ECDSAWithSHA256",
-		CommonName:   "forgerock",
 		PasswordPath: []string{"asdfSecret", "fdsaPassword"},
 	}
 	passwordKey := &KeyConfig{
@@ -102,8 +100,10 @@ func TestConfigurationStructLevelValidatorPKCS12(t *testing.T) {
 		Length: 32,
 	}
 	key := &KeyConfig{
-		Name: "fdsaKey",
-		Type: TypePKCS12,
+		Name:          "fdsaKey",
+		Type:          TypePKCS12,
+		KeyPassPath:   []string{"asdfSecret", "fdsaPassword"},
+		StorePassPath: []string{"asdfSecret", "fdsaPassword"},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -115,28 +115,61 @@ func TestConfigurationStructLevelValidatorPKCS12(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error, got none")
 	}
-	// valid
 	key.AliasConfigs = append(key.AliasConfigs, alias)
+	// valid
 	err = validate.Struct(config)
 	if err != nil {
 		t.Errorf("Expected no error, got: %+v", err)
 	}
+
+	// missing keyPassPath
+	key.KeyPassPath = nil
+	err = validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	// keyPassPath must be valid
+	key.KeyPassPath = []string{"asdfSecret", "non-existent"}
+	err = validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	key.KeyPassPath = []string{"asdfSecret", "fdsaPassword"}
+	// missing storePassPath
+	key.StorePassPath = nil
+	err = validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	// storePassPath must be valid
+	key.StorePassPath = []string{"asdfSecret", "non-existent"}
+	err = validate.Struct(config)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	key.StorePassPath = []string{"asdfSecret", "fdsaPassword"}
 }
 
 func TestConfigurationStructLevelValidatorCA(t *testing.T) {
 	alias := &AliasConfig{
-		Alias:      "fdsaAlias",
-		Type:       TypeCA,
-		Algorithm:  "ECDSAWithSHA256",
-		CommonName: "forgerock",
+		Alias: "fdsaAlias",
+		Type:  TypeCA,
+	}
+	passwordKey := &KeyConfig{
+		Name:   "fdsaPassword",
+		Type:   TypePassword,
+		Length: 32,
 	}
 	key := &KeyConfig{
-		Name:         "fdsaKey",
-		Type:         TypePKCS12,
-		AliasConfigs: []*AliasConfig{alias},
+		Name:          "fdsaKey",
+		Type:          TypePKCS12,
+		AliasConfigs:  []*AliasConfig{alias},
+		KeyPassPath:   []string{"asdfSecret", "fdsaPassword"},
+		StorePassPath: []string{"asdfSecret", "fdsaPassword"},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
+	config.Secrets[0].Keys = append(config.Secrets[0].Keys, passwordKey)
 	validate := validator.New()
 	validate.RegisterStructValidation(ConfigurationStructLevelValidator, Configuration{})
 	// missing passwordPath


### PR DESCRIPTION
StorePassPath and KeyPassPath should be parents of all aliases. Ensure tests support this.

Refactor dependency tree calculation to be much faster. Sort Parents and Children slices in tests to make refactoring easier and reduce brittleness during development.

Also, Algorithm and CommonName should not be part of TypeCA.

Increase configuration validation.