### PR TITLE
Tag docker images with the git commit id

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Tag and push image built with the git commit id
+TAG="${SOURCE_COMMIT:0:7}"
+docker tag "$IMAGE_NAME" "$DOCKER_REPO":"$TAG"
+docker push "$DOCKER_REPO":"$TAG"


### PR DESCRIPTION
This is a Dockerhub post_push hook to tag docker images with the git commit id.
Note: Dockerhub is setup to build+push images when pushing code to master. So this will not run as part of the PR docker build checks we have for PRs.

Closes #3