### PR TITLE
Add owner reference and update status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ citest: int-test
 	echo "Test successful"
 
 # Run unit and integration tests (backwards compatability)
-test: int-test
+test tests: int-test
 
 # Run unit tests
 unit-test: generate fmt vet manifests


### PR DESCRIPTION
1. Add owner reference to generated secrets
1. Update the SAC status when the reconcile loop is done

closes #61