### PR TITLE
Implement Literal KeyConfigType

### DIFF
--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -197,11 +197,15 @@ func (kp *CertKeyPair) ToKubernetes(secObject *corev1.Secret) {
 
 // LoadReferenceData loads references from data
 func (kp *CertKeyPair) LoadReferenceData(data []map[string][]byte) error {
+	var err error
 	if len(data) == 0 {
 		return errors.New("secret reference value not found")
 	}
 	rootCAData := data[0]
-	kp.RootCA = NewRootCA()
+	kp.RootCA, err = NewRootCA()
+	if err != nil {
+		return err
+	}
 	kp.RootCA.LoadFromData(rootCAData)
 	if kp.RootCA.IsEmpty() {
 		return errors.New("signing CA couldn't be loaded")

--- a/pkg/generator/certificate_test.go
+++ b/pkg/generator/certificate_test.go
@@ -15,7 +15,10 @@ import (
 func TestKeyPair(t *testing.T) {
 	loadKeyRefs := func(testKeyMgr KeyMgr) error {
 		// loading references
-		rootCA := NewRootCA()
+		rootCA, err := NewRootCA()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %+v", err)
+		}
 		rootCA.Generate()
 		rootCAData := make([]map[string][]byte, 1)
 		rootCAData[0] = make(map[string][]byte, 2)

--- a/pkg/generator/literal.go
+++ b/pkg/generator/literal.go
@@ -1,0 +1,105 @@
+package generator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+	"github.com/ForgeRock/secret-agent/pkg/secretsmanager"
+)
+
+// Literal randomly generated of specified length
+type Literal struct {
+	Name        string
+	Value       []byte
+	ConfigValue []byte
+}
+
+// References return names of secrets that should be looked up
+func (literal *Literal) References() ([]string, []string) {
+	return []string{}, []string{}
+}
+
+// LoadReferenceData loads references from data
+func (literal *Literal) LoadReferenceData(data []map[string][]byte) error {
+	return nil
+}
+
+// LoadSecretFromManager populates Literal data from secret manager
+func (literal *Literal) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+	var err error
+	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
+	literal.Value, err = secretsmanager.LoadSecret(context, config, literalFmt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnsureSecretManager populates secrets manager from Literal data
+func (literal *Literal) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+	var err error
+	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
+	err = secretsmanager.EnsureSecret(context, config, literalFmt, literal.Value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// InSecret return true if the key is one found in the secret
+func (literal *Literal) InSecret(secObject *corev1.Secret) bool {
+	if secObject.Data == nil || secObject.Data[literal.Name] == nil || literal.IsEmpty() {
+		if secObject.Data[literal.Name] == nil {
+			return false
+		}
+		return false
+	}
+	if bytes.Compare(literal.Value, secObject.Data[literal.Name]) == 0 {
+		return true
+	}
+	return false
+
+}
+
+// Generate generates data
+func (literal *Literal) Generate() error {
+	literal.Value = literal.ConfigValue
+	return nil
+}
+
+// IsEmpty boolean determines if the struct is empty
+func (literal *Literal) IsEmpty() bool {
+	if len(literal.Value) == 0 {
+		return true
+	}
+	return false
+
+}
+
+// LoadFromData loads data from kubernetes secret
+func (literal *Literal) LoadFromData(secData map[string][]byte) {
+	literal.Value = secData[literal.Name]
+	return
+}
+
+// ToKubernetes "marshals" object to kubernetes object
+func (literal *Literal) ToKubernetes(secret *corev1.Secret) {
+	// data could be nil
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[literal.Name] = literal.Value
+}
+
+// NewLiteral creates new Literal type for reconcilation
+func NewLiteral(keyConfig *v1alpha1.KeyConfig) (*Literal, error) {
+	literal := &Literal{
+		Name:        keyConfig.Name,
+		ConfigValue: []byte(keyConfig.Spec.Value),
+	}
+	return literal, nil
+}

--- a/pkg/generator/literal_test.go
+++ b/pkg/generator/literal_test.go
@@ -1,0 +1,28 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+)
+
+func TestGenerateLiteral(t *testing.T) {
+	kc := &v1alpha1.KeyConfig{
+		Name: "testConfig",
+		Type: "literal",
+		Spec: &v1alpha1.KeySpec{
+			Value: "literal",
+		},
+	}
+	literal, err := NewLiteral(kc)
+	if err != nil {
+		t.Errorf("Expected no error, got: %+v", err)
+	}
+	err = literal.Generate()
+	if err != nil {
+		t.Errorf("Expected no error, got: %+v", err)
+	}
+	if string(literal.Value) != "literal" {
+		t.Errorf("Expected value was 'literal' but found %s", literal.Value)
+	}
+}

--- a/pkg/generator/password.go
+++ b/pkg/generator/password.go
@@ -42,7 +42,7 @@ func (pwd *Password) LoadSecretFromManager(context context.Context, config *v1al
 	return nil
 }
 
-// EnsureSecretManager populates secrete manager from Password data
+// EnsureSecretManager populates secrets manager from Password data
 func (pwd *Password) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
 	var err error
 	pwdFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, pwd.Name)

--- a/pkg/generator/rootca.go
+++ b/pkg/generator/rootca.go
@@ -28,9 +28,9 @@ type RootCA struct {
 }
 
 // NewRootCA create new RootCA struct
-func NewRootCA() *RootCA {
+func NewRootCA() (*RootCA, error) {
 	cert := &Certificate{}
-	return &RootCA{Cert: cert}
+	return &RootCA{Cert: cert}, nil
 }
 
 // References return names of secrets that should be looked up

--- a/pkg/generator/rootca_test.go
+++ b/pkg/generator/rootca_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestRootCA(t *testing.T) {
-	rootCA := NewRootCA()
+	rootCA, err := NewRootCA()
+	if err != nil {
+		t.Fatalf("Expected no error, got: %+v", err)
+	}
 
 	// test IsEmpty when empty
 	if empty := rootCA.IsEmpty(); !empty {


### PR DESCRIPTION
1. Implement Literal KeyConfigType
1. Make NewRootCA consistent with other generators. Returns error
1. Fix typos in password.go

closes #64