### PR TITLE
Enhancements to webhooks, webhook certs, tests, types

### DIFF
--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -72,46 +72,15 @@ type SecretAgentConfigurationList struct {
 
 // DistinguishedName certificate subject data
 type DistinguishedName struct {
-	Country            []string `json:"country,omitempty" yaml:"country,omitempty"`
-	Organization       []string `json:"organization,omitempty" yaml:"organization,omitempty"`
-	OrganizationalUnit []string `json:"organizationUnit,omitempty" yaml:"organizationUnit,omitempty"`
-	Locality           []string `json:"locality,omitempty" yaml:"locality,omitempty"`
-	Province           []string `json:"province,omitempty" yaml:"province,omitempty"`
-	StreetAddress      []string `json:"streetAddress,omitempty" yaml:"streetAddress,omitempty"`
-	PostalCode         []string `json:"postalCode,omitempty" yaml:"postalCode,omitempty"`
-	SerialNumber       string   `json:"serialNumber,omitempty" yaml:"serialNumber,omitempty"`
-	CommonName         string   `json:"commonName,omitempty" yaml:"commonName,omitempty,flow"`
-}
-
-func (dn *DistinguishedName) isEmpty() bool {
-	if len(dn.Country) != 0 {
-		return true
-	}
-	if len(dn.Organization) != 0 {
-		return true
-	}
-	if len(dn.OrganizationalUnit) != 0 {
-		return true
-	}
-	if len(dn.Locality) != 0 {
-		return true
-	}
-	if len(dn.Province) != 0 {
-		return true
-	}
-	if len(dn.StreetAddress) != 0 {
-		return true
-	}
-	if len(dn.PostalCode) != 0 {
-		return true
-	}
-	if dn.SerialNumber == "" {
-		return true
-	}
-	if dn.CommonName == "" {
-		return true
-	}
-	return false
+	Country            []string `json:"country,omitempty"`
+	Organization       []string `json:"organization,omitempty"`
+	OrganizationalUnit []string `json:"organizationUnit,omitempty"`
+	Locality           []string `json:"locality,omitempty"`
+	Province           []string `json:"province,omitempty"`
+	StreetAddress      []string `json:"streetAddress,omitempty"`
+	PostalCode         []string `json:"postalCode,omitempty"`
+	SerialNumber       string   `json:"serialNumber,omitempty"`
+	CommonName         string   `json:"commonName,omitempty"`
 }
 
 func init() {
@@ -246,6 +215,7 @@ type KeySpec struct {
 	KeyPassPath           string             `json:"keyPassPath,omitempty"`
 	Sans                  []string           `json:"sans,omitempty"`
 	TruststoreImportPaths []string           `json:"truststoreImportPaths,omitempty"`
+	Duration              *metav1.Duration   `json:"Duration,omitempty"`
 
 	// +kubebuilder:validation:Minimun=16
 	Length *int `json:"length,omitempty"`
@@ -263,6 +233,77 @@ type KeytoolAliasConfig struct {
 	Args            []string   `json:"args,omitempty"`
 	SourcePath      string     `json:"sourcePath,omitempty"`
 	DestinationPath string     `json:"destinationPath,omitempty"`
+}
+
+func (ks *KeySpec) isEmpty() bool {
+	if len(ks.Value) != 0 {
+		return false
+	}
+	if len(ks.Algorithm) != 0 {
+		return false
+	}
+	if ks.DistinguishedName != nil && !ks.DistinguishedName.isEmpty() {
+		return false
+	}
+	if len(ks.SignedWithPath) != 0 {
+		return false
+	}
+	if len(ks.StoreType) != 0 {
+		return false
+	}
+	if len(ks.StorePassPath) != 0 {
+		return false
+	}
+	if len(ks.KeyPassPath) != 0 {
+		return false
+	}
+	if len(ks.Sans) != 0 {
+		return false
+	}
+	if ks.Duration != nil {
+		return false
+	}
+	if len(ks.TruststoreImportPaths) != 0 {
+		return false
+	}
+	if ks.Length != nil {
+		return false
+	}
+	if len(ks.KeytoolAliases) != 0 {
+		return false
+	}
+	return true
+}
+
+func (dn *DistinguishedName) isEmpty() bool {
+	if len(dn.Country) != 0 {
+		return false
+	}
+	if len(dn.Organization) != 0 {
+		return false
+	}
+	if len(dn.OrganizationalUnit) != 0 {
+		return false
+	}
+	if len(dn.Locality) != 0 {
+		return false
+	}
+	if len(dn.Province) != 0 {
+		return false
+	}
+	if len(dn.StreetAddress) != 0 {
+		return false
+	}
+	if len(dn.PostalCode) != 0 {
+		return false
+	}
+	if dn.SerialNumber == "" {
+		return false
+	}
+	if dn.CommonName == "" {
+		return false
+	}
+	return true
 }
 
 // TODO

--- a/api/v1alpha1/secretagentconfiguration_types_test.go
+++ b/api/v1alpha1/secretagentconfiguration_types_test.go
@@ -10,6 +10,12 @@ func TestConfigurationStructLevelValidatorCA(t *testing.T) {
 	key := &KeyConfig{
 		Name: "foo",
 		Type: KeyConfigTypeCA,
+		Spec: &KeySpec{
+			Duration: nil,
+			DistinguishedName: &DistinguishedName{
+				CommonName: "bar",
+			},
+		},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -19,19 +25,13 @@ func TestConfigurationStructLevelValidatorCA(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got: %+v", err)
 	}
-	// Spec must be empty
-	key.Spec = new(KeySpec)
-	config.Secrets[0].Keys[0] = key
-	err = validate.Struct(config)
-	if err == nil {
-		t.Error("Spec must be empty: Expected error, got none")
-	}
 }
 
 func TestConfigurationStructLevelValidatorLiteral(t *testing.T) {
 	key := &KeyConfig{
 		Name: "fdsa",
 		Type: KeyConfigTypeLiteral,
+		Spec: &KeySpec{},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -55,6 +55,7 @@ func TestConfigurationStructLevelValidatorPassword(t *testing.T) {
 	key := &KeyConfig{
 		Name: "fdsa",
 		Type: KeyConfigTypePassword,
+		Spec: &KeySpec{},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -66,7 +67,6 @@ func TestConfigurationStructLevelValidatorPassword(t *testing.T) {
 		t.Error("Missing Length: Expected error, got none")
 	}
 	// valid
-	config.Secrets[0].Keys[0].Spec = new(KeySpec)
 	config.Secrets[0].Keys[0].Spec.Length = new(int)
 	*config.Secrets[0].Keys[0].Spec.Length = 16
 	err = validate.Struct(config)
@@ -79,6 +79,7 @@ func TestConfigurationStructLevelValidatorSSH(t *testing.T) {
 	key := &KeyConfig{
 		Name: "foo",
 		Type: KeyConfigTypeSSH,
+		Spec: &KeySpec{},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -87,13 +88,6 @@ func TestConfigurationStructLevelValidatorSSH(t *testing.T) {
 	err := validate.Struct(config)
 	if err != nil {
 		t.Errorf("Expected no error, got: %+v", err)
-	}
-	// spec must be empty
-	key.Spec = new(KeySpec)
-	config.Secrets[0].Keys[0] = key
-	err = validate.Struct(config)
-	if err == nil {
-		t.Error("Spec must be empty: Expected error, got none")
 	}
 }
 
@@ -111,6 +105,12 @@ func TestConfigurationStructLevelValidatorKeyPair(t *testing.T) {
 	ca := &KeyConfig{
 		Name: "ca",
 		Type: KeyConfigTypeCA,
+		Spec: &KeySpec{
+			Duration: nil,
+			DistinguishedName: &DistinguishedName{
+				CommonName: "foo",
+			},
+		},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -190,6 +190,12 @@ func TestConfigurationStructLevelValidatorKeytool(t *testing.T) {
 	ca := &KeyConfig{
 		Name: "ca",
 		Type: KeyConfigTypeCA,
+		Spec: &KeySpec{
+			Duration: nil,
+			DistinguishedName: &DistinguishedName{
+				CommonName: "bar",
+			},
+		},
 	}
 
 	pwd := &KeyConfig{
@@ -336,6 +342,12 @@ func TestConfigurationStructLevelValidatorDuplicateSecretName(t *testing.T) {
 	key := &KeyConfig{
 		Name: "foo",
 		Type: KeyConfigTypeCA,
+		Spec: &KeySpec{
+			Duration: nil,
+			DistinguishedName: &DistinguishedName{
+				CommonName: "bar",
+			},
+		},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)
@@ -353,6 +365,12 @@ func TestConfigurationStructLevelValidatorDuplicateKeys(t *testing.T) {
 	key := &KeyConfig{
 		Name: "foo",
 		Type: KeyConfigTypeCA,
+		Spec: &KeySpec{
+			Duration: nil,
+			DistinguishedName: &DistinguishedName{
+				CommonName: "bar",
+			},
+		},
 	}
 	config := getConfig()
 	config.Secrets[0].Keys = append(config.Secrets[0].Keys, key)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -207,6 +208,11 @@ func (in *KeySpec) DeepCopyInto(out *KeySpec) {
 		in, out := &in.TruststoreImportPaths, &out.TruststoreImportPaths
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.Length != nil {
 		in, out := &in.Length, &out.Length

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -162,6 +162,8 @@ spec:
                         spec:
                           description: KeySpec is the configuration for each key
                           properties:
+                            Duration:
+                              type: string
                             algorithm:
                               description: AlgorithmType Specifies which keystore
                                 algorithm to use

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -15,11 +15,17 @@ spec:
     keys:
     - name: ca
       type: ca
+      spec:
+        distinguishedName:
+          commonName: platform-ca
 
   - name: vault-secrets
     keys:
     - name: vault-ca
       type: ca
+      spec:
+        distinguishedName:
+          commonName: vault-secrets
 
   - name: amster-ssh
     keys:

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -14,7 +14,7 @@ const (
 // KeyMgr an interface for managing secret data
 type KeyMgr interface {
 	References() ([]string, []string)
-	LoadReferenceData(data []map[string][]byte) error
+	LoadReferenceData(data map[string][]byte) error
 	LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error
 	EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error
 	Generate() error

--- a/pkg/generator/literal.go
+++ b/pkg/generator/literal.go
@@ -24,7 +24,7 @@ func (literal *Literal) References() ([]string, []string) {
 }
 
 // LoadReferenceData loads references from data
-func (literal *Literal) LoadReferenceData(data []map[string][]byte) error {
+func (literal *Literal) LoadReferenceData(data map[string][]byte) error {
 	return nil
 }
 

--- a/pkg/generator/password.go
+++ b/pkg/generator/password.go
@@ -27,7 +27,7 @@ func (pwd *Password) References() ([]string, []string) {
 }
 
 // LoadReferenceData loads references from data
-func (pwd *Password) LoadReferenceData(data []map[string][]byte) error {
+func (pwd *Password) LoadReferenceData(data map[string][]byte) error {
 	return nil
 }
 

--- a/pkg/generator/rootca_test.go
+++ b/pkg/generator/rootca_test.go
@@ -4,12 +4,27 @@ import (
 	"bytes"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRootCA(t *testing.T) {
-	rootCA, err := NewRootCA()
+	kc := &v1alpha1.KeyConfig{
+		Name: "testConfig",
+		Type: "ca",
+		Spec: &v1alpha1.KeySpec{
+			Duration: nil,
+			DistinguishedName: &v1alpha1.DistinguishedName{
+				CommonName: "foo",
+			},
+		},
+	}
+	kc.Spec.Duration = new(metav1.Duration)
+	kc.Spec.Duration.Duration, _ = time.ParseDuration("90d")
+	rootCA, err := NewRootCA(kc)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %+v", err)
 	}


### PR DESCRIPTION
1. Update the webhook_cabundler to use new ca and keypair generate funcs
1. Make distinguishedName a required field for ca key type
1.  Add `duration` to keyConfig.KeySpec to be used by `ca`,  `keypair`
1. Update sample secret-agent config
1. Implement duration for ca key types
1. Implement distinguishedName for ca key types
1. Fix bug in webhook.Defaulter when calling cleanUpPaths
1. Change NewRootCa to take a KeyConfig as argument
1. Clean up unused code from certificate.go and related tests
1. Update tests to account for changes mentioned above
1. Update ConfigurationStructLevelValidator to account for changes above

Closes #59