### PR TITLE
Implement genkeypair cmd for keytool type

### DIFF
--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -230,10 +230,9 @@ type KeytoolAliasConfig struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 	// +kubebuilder:validation:Required
-	Cmd             KeytoolCmd `json:"cmd"`
-	Args            []string   `json:"args,omitempty"`
-	SourcePath      string     `json:"sourcePath,omitempty"`
-	DestinationPath string     `json:"destinationPath,omitempty"`
+	Cmd        KeytoolCmd `json:"cmd"`
+	Args       []string   `json:"args,omitempty"`
+	SourcePath string     `json:"sourcePath,omitempty"`
 }
 
 func (ks *KeySpec) isEmpty() bool {

--- a/api/v1alpha1/secretagentconfiguration_types_test.go
+++ b/api/v1alpha1/secretagentconfiguration_types_test.go
@@ -237,10 +237,9 @@ func TestConfigurationStructLevelValidatorKeytool(t *testing.T) {
 					SourcePath: "asdfSecret/keypa",
 				},
 				{
-					Name:            "gentest",
-					Cmd:             "genkeypair",
-					Args:            []string{"yadayada", "foo", "bar"},
-					DestinationPath: "asdfSecret/kt",
+					Name: "gentest",
+					Cmd:  "genkeypair",
+					Args: []string{"yadayada", "foo", "bar"},
 				},
 			},
 		},
@@ -312,22 +311,6 @@ func TestConfigurationStructLevelValidatorKeytool(t *testing.T) {
 		t.Error("Wrong Alias SourcePath: Expected error, got none")
 	}
 	config.Secrets[0].Keys[3].Spec.KeytoolAliases[0].SourcePath = "asdfSecret/ca"
-
-	// Missing Alias DestinationPath
-	config.Secrets[0].Keys[3].Spec.KeytoolAliases[2].DestinationPath = ""
-	err = validate.Struct(config)
-	if err == nil {
-		t.Error("Missing Alias DestinationPath: Expected error, got none")
-	}
-	config.Secrets[0].Keys[3].Spec.KeytoolAliases[2].DestinationPath = "asdfSecret/kt"
-
-	// wrong Alias DestinationPath
-	config.Secrets[0].Keys[3].Spec.KeytoolAliases[2].DestinationPath = "asdfSecret/wrong"
-	err = validate.Struct(config)
-	if err == nil {
-		t.Error("Wrong Alias DestinationPath: Expected error, got none")
-	}
-	config.Secrets[0].Keys[3].Spec.KeytoolAliases[2].DestinationPath = "asdfSecret/kt"
 
 	// Missing keytoolAliases
 	config.Secrets[0].Keys[3].Spec.KeytoolAliases = nil

--- a/api/v1alpha1/secretagentconfiguration_webhook.go
+++ b/api/v1alpha1/secretagentconfiguration_webhook.go
@@ -83,7 +83,6 @@ func (r *SecretAgentConfiguration) Default() {
 			}
 			for idx, alias := range key.Spec.KeytoolAliases {
 				r.Spec.Secrets[secretIndex].Keys[keysIndex].Spec.KeytoolAliases[idx].SourcePath = cleanUpPaths(alias.SourcePath)
-				r.Spec.Secrets[secretIndex].Keys[keysIndex].Spec.KeytoolAliases[idx].DestinationPath = cleanUpPaths(alias.DestinationPath)
 			}
 		}
 	}
@@ -312,16 +311,6 @@ func ConfigurationStructLevelValidator(sl validator.StructLevel) {
 							return
 						}
 					case KeytoolCmdGenkeypair, KeytoolCmdGenseckey:
-						if alias.DestinationPath == "" {
-							sl.ReportError(config.Secrets[secretIndex].Keys[keyIndex].Spec.KeytoolAliases[aliasIndex],
-								name, "destinationPass", "destinationPassNotSet", "")
-							return
-						}
-						if !pathExistsInSecretAgentConfiguration(alias.DestinationPath, config.Secrets) {
-							sl.ReportError(config.Secrets[secretIndex].Keys[keyIndex].Spec.KeytoolAliases[aliasIndex].DestinationPath,
-								name, "destinationPath", "destinationPathNotValid", "")
-							return
-						}
 						if len(alias.Args) == 0 {
 							sl.ReportError(config.Secrets[secretIndex].Keys[keyIndex].Spec.KeytoolAliases[aliasIndex],
 								name, "args", "argsNotSet", "")

--- a/api/v1alpha1/v1alpha1_test.go
+++ b/api/v1alpha1/v1alpha1_test.go
@@ -157,10 +157,9 @@ var _ = Describe("SecretAgentConfiguration", func() {
 										KeyPassPath:   "path/2",
 										KeytoolAliases: []*KeytoolAliasConfig{
 											{
-												Name:            "name1",
-												Cmd:             "genkeypair",
-												Args:            []string{"arg1", "arg2"},
-												DestinationPath: "path/3",
+												Name: "name1",
+												Cmd:  "genkeypair",
+												Args: []string{"arg1", "arg2"},
 											},
 											{
 												Name:       "name2",

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -167,8 +167,6 @@ spec:
                                     - importcert
                                     - importpassword
                                     type: string
-                                  destinationPath:
-                                    type: string
                                   name:
                                     type: string
                                   sourcePath:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,7 +43,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
+            cpu: 1000m
             memory: 100Mi
           requests:
             cpu: 100m

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -93,6 +93,19 @@ spec:
       spec:
         value: amadmin
 
+  - name: idm-env-secrets
+    keys:
+    - name: OPENIDM_ADMIN_PASSWORD
+      type: password
+    - name: OPENIDM_KEYSTORE_PASSWORD
+      type: password
+    - name: OPENIDM_REPO_PASSWORD
+      type: password
+    - name: RS_CLIENT_SECRET
+      type: password
+    - name: USERSTORE_PASSWORD
+      type: password
+
   - name: am-keystore
     keys:
     - name: keystore.jceks
@@ -102,25 +115,78 @@ spec:
         storePassPath: am-passwords/.storepass
         keyPassPath: am-passwords/.keypass
         keytoolAliases:
-          - name: rsajwtsigningkey
-            cmd: genkeypair
-            args: ["-keyalg", "RSA", "-keysize", "2048", "-validity", "7300"]
-            destinationPath: truststore/cacerts
-          - name: ec256test
-            cmd: genkeypair
-            args : ["-keyalg", "EC","-sigalg",  "SHA256withECDSA", "-dname", "CN=ForgeRock", "-keysize", "256"]
-            destinationPath: truststore/cacerts
-          - name: hmacsigningtest
-            cmd: genseckey
-            args: ["-keyalg", "HMacSHA512", "-keysize", "512"]
-            destinationPath: truststore/cacerts
-          - name: configstorepwd
-            cmd: importpassword
-            sourcePath: am-passwords/.storepass
-          - name: my-imported-cert
-            cmd: importcert
-            sourcePath: truststore/cacerts
+        - name: rsajwtsigningkey
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=rsajwtsigningkey,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: ec256test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "256", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es256test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: es384test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "384", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es384test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: es512test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "512", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es512test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: selfserviceenctest
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=selfserviceenctest,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: test
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: hmacsigningtest
+          cmd: genseckey
+          args: ["-keyalg", "HMacSHA512", "-keysize", "512"]
+        - name: selfservicesigntest
+          cmd: genseckey
+          args: ["-keyalg", "HMacSHA512", "-keysize", "256"]
+        - name: directenctest
+          cmd: genseckey
+          args: ["-keyalg", "aes", "-keysize", "256"]
+        - name: configstorepwd
+          cmd: importpassword
+          sourcePath: am-passwords/.storepass
+        - name: dsameuserpwd
+          cmd: importpassword
+          sourcePath: ds-env-secrets/dirmanager.pw
+        - name: my-imported-cert
+          cmd: importcert
+          sourcePath: truststore/cacerts
+        # TODO
+        # keytool -importkeystore -destalias sms.transport.key -srcalias sms.transport.key -srcstoretype jceks -srckeystore sms-transport-key/sms-transport-key.jceks -srckeypass:file sms-transport-key/keypass -srcstorepass:file sms-transport-key/storepass -destkeystore /opt/gen/secrets/generic/am-keystore/keystore.jceks -deststoretype jceks -deststorepass zzggthedwwd4pegt1tth02drmxfbdw01 -destkeypass is4spw1bfagasmsc0gpgd2gwrgrzchz0
+    - name: truststore
+      type: truststore
+      spec:
+        #TODO. Verify truststore value
+        truststoreImportPaths: ["platform-ca/ca"]
 
+  - name: idm
+    keys:
+    - name: keystore.jceks
+      type: keytool
+      spec:
+        storeType: jceks
+        storePassPath: am-passwords/.storepass
+        keyPassPath: am-passwords/.keypass
+        keytoolAliases:
+        - name: openidm-sym-default
+          cmd: genseckey
+          args: ["-keyalg", "aes", "-keysize", "128"]
+        - name: openidm-jwtsessionhmac-key
+          cmd: genseckey
+          args: ["-keyalg", "HmacSHA256", "-keysize", "256"]
+        - name: openidm-selfservice-key
+          cmd: genseckey
+          args: ["-keyalg", "aes", "-keysize", "128"]
+        - name: server-cert 
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=server-cert,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: selfservice
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=selfservice,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: openidm-localhost
+          cmd: genkeypair
+          args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=openidm-localhost,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+  
   - name: truststore
     keys:
       - name: cacerts

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	google.golang.org/appengine v1.6.6
 	google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380
 	google.golang.org/grpc v1.29.1
 	k8s.io/api v0.17.8

--- a/pkg/generator/keytoolgenkeypair.go
+++ b/pkg/generator/keytoolgenkeypair.go
@@ -1,0 +1,46 @@
+package generator
+
+import (
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// KeyToolGenKeyPair alias password manager
+type KeyToolGenKeyPair struct {
+	v1aliasConfig *v1alpha1.KeytoolAliasConfig
+	refName       string
+}
+
+// NewKeyToolGenKeyPair create a new password alias manager
+func NewKeyToolGenKeyPair(alias *v1alpha1.KeytoolAliasConfig) *KeyToolGenKeyPair {
+	return &KeyToolGenKeyPair{
+		v1aliasConfig: alias,
+	}
+}
+
+// References get list of refences needed for generated a alias
+func (kp *KeyToolGenKeyPair) References() ([]string, []string) {
+	return []string{}, []string{}
+}
+
+// LoadReferenceData loads data from references
+func (kp *KeyToolGenKeyPair) LoadReferenceData(data map[string][]byte) error {
+	return nil
+}
+
+// Generate creates keytool password alias entry
+func (kp *KeyToolGenKeyPair) Generate(baseCmd cmdRunner) error {
+	//++ keytool -genkeypair -alias rsajwtsigningkey -dname CN=rsajwtsigningkey,O=ForgeRock,L=Bristol,ST=Bristol,C=UK -keyalg RSA -keysize 2048 -sigalg SHA256WITHRSA --validity 3650
+	// KS_PROPS="-keystore ${KEYSTORE} -storetype ${STORE_TYPE} -storepass ${STORE_PASS} -keypass ${KEY_PASS}"
+	cmd := "-genkeypair"
+	args := []string{
+		"-alias", kp.v1aliasConfig.Name,
+	}
+	args = append(args, kp.v1aliasConfig.Args...)
+	keyToolCmd := baseCmd(cmd, args)
+	output, err := keyToolCmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, string(output))
+	}
+	return nil
+}

--- a/pkg/generator/keytoolgenkeypair_test.go
+++ b/pkg/generator/keytoolgenkeypair_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ForgeRock/secret-agent/api/v1alpha1"
 )
 
-func TestImportPassword(t *testing.T) {
+func TestGenKeyPair(t *testing.T) {
 	length := 32
 	kc := &v1alpha1.KeyConfig{
-		Name: "testimportpass",
+		Name: "test",
 		Type: "password",
 		Spec: &v1alpha1.KeySpec{
 			Length: &length,
@@ -27,9 +27,11 @@ func TestImportPassword(t *testing.T) {
 			KeyPassPath:   "keypass/pass",
 			KeytoolAliases: []*v1alpha1.KeytoolAliasConfig{
 				{
-					Name:       "testimportpass",
-					Cmd:        "importpassword",
-					SourcePath: "testpass/pass",
+					Name: "testkp",
+					Cmd:  "genkeypair",
+					Args: []string{"-keyalg", "RSA", "-keysize", "2048",
+						"-sigalg", "SHA256WITHRSA", "-validity", "3650",
+						"-dname", "CN=testkp,O=SA,L=Bristol,ST=Bristol,C=UK"},
 				},
 			},
 		},
@@ -63,7 +65,7 @@ func TestImportPassword(t *testing.T) {
 	}
 	baseCmd := keyToolMgr.baseCommand(*keytoolPath, baseArgs)
 	args := []string{
-		"-alias", "testimportpass",
+		"-alias", "testkp",
 	}
 	if _, err := os.Stat(keyToolMgr.storePath); !os.IsNotExist(err) {
 		t.Error("expected keyToolMgr to cleanup store but didn't")

--- a/pkg/generator/keytoolimportpassword.go
+++ b/pkg/generator/keytoolimportpassword.go
@@ -23,7 +23,7 @@ type KeyToolImportPassword struct {
 	refData       []byte
 }
 
-// Reference get list of refences needed for generated a alias
+// References get list of refences needed for generated a alias
 func (kp *KeyToolImportPassword) References() ([]string, []string) {
 	kp.refName, kp.refDataKey = handleRefPath(kp.v1aliasConfig.SourcePath)
 	return []string{kp.refName}, []string{kp.refDataKey}


### PR DESCRIPTION
1. Implement new genkeypair alias cmd for the keytool secret type.
1. Remove DestinationPath. This is not required to genKeyPair
1. Add more elements to the sample SAC
1. Increase CPU limit to 1000m. Keytool operations are power hungry

closes #78