### PR TITLE
controller stores reference secrets using composite of name and data key

### DIFF
--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -197,10 +197,11 @@ func (kp *CertKeyPair) LoadReferenceData(data map[string][]byte) error {
 	if len(data) == 0 {
 		return errors.New("secret reference value not found")
 	}
-	kp.RootCA = &RootCA{
-		Cert: &Certificate{},
+	rootData := map[string][]byte{
+		"ca.pem":         data[fmt.Sprintf("%s/%s", kp.refName, "ca.pem")],
+		"ca-private.pem": data[fmt.Sprintf("%s/%s", kp.refName, "ca-private.pem")],
 	}
-	kp.RootCA.LoadFromData(data)
+	kp.RootCA.LoadFromData(rootData)
 	if kp.RootCA.IsEmpty() {
 		return errors.New("signing CA couldn't be loaded")
 	}
@@ -209,8 +210,12 @@ func (kp *CertKeyPair) LoadReferenceData(data map[string][]byte) error {
 
 // NewCertKeyPair creates new CertKeyPair type for reconcilation
 func NewCertKeyPair(keyConfig *v1alpha1.KeyConfig) (*CertKeyPair, error) {
-	keyPair := &CertKeyPair{
+	rootCA := &RootCA{
 		Cert: &Certificate{},
+	}
+	keyPair := &CertKeyPair{
+		Cert:   &Certificate{},
+		RootCA: rootCA,
 	}
 	keyPair.Name = keyConfig.Name
 	secretRef, dataKey := handleRefPath(keyConfig.Spec.SignedWithPath)

--- a/pkg/generator/certificate_test.go
+++ b/pkg/generator/certificate_test.go
@@ -21,8 +21,9 @@ func TestKeyPair(t *testing.T) {
 		}
 		rootCA.Generate()
 		rootCAData := make(map[string][]byte, 1)
-		rootCAData["ca.pem"] = rootCA.Cert.CertPEM
-		rootCAData["ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
+		rootCAData["foo/ca.pem"] = rootCA.Cert.CertPEM
+		rootCAData["foo/ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
+
 		return testKeyMgr.LoadReferenceData(rootCAData)
 	}
 	key := &v1alpha1.KeyConfig{

--- a/pkg/generator/importpassword_test.go
+++ b/pkg/generator/importpassword_test.go
@@ -49,7 +49,9 @@ func TestImportPassword(t *testing.T) {
 	}
 	keyToolMgr.References()
 	keyToolMgr.LoadReferenceData(map[string][]byte{
-		"pass": pwdMgr.Value,
+		"storepass/pass": []byte("storepassword"),
+		"keypass/pass":   []byte("storepassword"),
+		"testpass/pass":  pwdMgr.Value,
 	})
 	err = keyToolMgr.Generate()
 	if err != nil {
@@ -61,7 +63,7 @@ func TestImportPassword(t *testing.T) {
 		"-keypass", keyToolMgr.keyPassValue,
 		"-keystore", keyToolMgr.storePath,
 	}
-	baseCmd := keyToolMgr.baseCommand(*keytoolPath, baseArgs)
+	baseCmd := execCommand(*keytoolPath, baseArgs)
 	args := []string{
 		"-alias", "testimportpass",
 	}

--- a/pkg/generator/keytoolgenkeypair_test.go
+++ b/pkg/generator/keytoolgenkeypair_test.go
@@ -51,7 +51,8 @@ func TestGenKeyPair(t *testing.T) {
 	}
 	keyToolMgr.References()
 	keyToolMgr.LoadReferenceData(map[string][]byte{
-		"pass": pwdMgr.Value,
+		"storepass/pass": pwdMgr.Value,
+		"keypass/pass":   []byte("password1"),
 	})
 	err = keyToolMgr.Generate()
 	if err != nil {
@@ -59,11 +60,11 @@ func TestGenKeyPair(t *testing.T) {
 	}
 	baseArgs := []string{
 		"-storetype", string(keyToolMgr.V1Spec.StoreType),
-		"-storepass", keyToolMgr.storePassValue,
+		// "-storepass", keyToolMgr.storePassValue,
 		"-keypass", keyToolMgr.keyPassValue,
 		"-keystore", keyToolMgr.storePath,
 	}
-	baseCmd := keyToolMgr.baseCommand(*keytoolPath, baseArgs)
+	baseCmd := execCommand(*keytoolPath, baseArgs)
 	args := []string{
 		"-alias", "testkp",
 	}

--- a/pkg/generator/keytoolimportpassword.go
+++ b/pkg/generator/keytoolimportpassword.go
@@ -31,7 +31,7 @@ func (kp *KeyToolImportPassword) References() ([]string, []string) {
 
 // LoadReferenceData loads data from references
 func (kp *KeyToolImportPassword) LoadReferenceData(data map[string][]byte) error {
-	if value, ok := data[kp.refDataKey]; ok {
+	if value, ok := data[kp.v1aliasConfig.SourcePath]; ok {
 		kp.refData = value
 	}
 	return nil

--- a/pkg/generator/truststore.go
+++ b/pkg/generator/truststore.go
@@ -67,8 +67,8 @@ func (ts *TrustStore) References() ([]string, []string) {
 
 // LoadReferenceData load all alias reference data
 func (ts *TrustStore) LoadReferenceData(data map[string][]byte) error {
-	for _, key := range ts.refDataKeys {
-		if value, ok := data[key]; ok {
+	for index, key := range ts.refDataKeys {
+		if value, ok := data[fmt.Sprintf("%s/%s", ts.refKeys[index], key)]; ok {
 			ts.refData = append(ts.refData, value...)
 		} else {
 			return errors.New(fmt.Sprintf("Reference Data Not Foundi for key: %s", key))

--- a/pkg/generator/truststore_test.go
+++ b/pkg/generator/truststore_test.go
@@ -31,7 +31,9 @@ func TestTrustStore(t *testing.T) {
 		t.Fatalf("expected no error found: %s", err)
 	}
 	tsMgr.References()
-	tsMgr.LoadReferenceData(testSecret.Data)
+	tsMgr.LoadReferenceData(map[string][]byte{
+		"testconfig/ca.pem": testSecret.Data["ca.pem"],
+	})
 	tsMgr.Generate()
 	parsed, err := pkcs12.DecodeTrustStore(tsMgr.Value, "changeit")
 	if err != nil {


### PR DESCRIPTION
Controller stores reference data using both slices returned from
References(). The keyname pattern is "slice1[i]/slice2[i]". For most
KeyMgrs this will match the pattern used in the Spec. Root Certs and SSH
keys are different and use specific names always.

KeyMgr.LoadReferenceData(data) should now expect to data to be keyed "slice1[i]/slice2[i]"

closes #84