### PR TITLE
Import keystore aliasmgr

### DIFF
--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -152,7 +152,7 @@ const (
 )
 
 // KeytoolCmd Specifies the keytool command to use.
-// +kubebuilder:validation:Enum=genkeypair;genseckey;importcert;importpassword
+// +kubebuilder:validation:Enum=genkeypair;genseckey;importcert;importpassword;importkeystore
 type KeytoolCmd string
 
 // Key Config Type Strings
@@ -161,6 +161,7 @@ const (
 	KeytoolCmdGenseckey      KeytoolCmd = "genseckey"
 	KeytoolCmdImportcert     KeytoolCmd = "importcert"
 	KeytoolCmdImportpassword KeytoolCmd = "importpassword"
+	KeytoolCmdImportkeystore KeytoolCmd = "importkeystore"
 )
 
 // AppConfig is the configuration for the forgeops-secrets application

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -166,6 +166,7 @@ spec:
                                     - genseckey
                                     - importcert
                                     - importpassword
+                                    - importkeystore
                                     type: string
                                   name:
                                     type: string

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -81,13 +81,13 @@ spec:
         keyPassPath: ds/keystore.pin
         keytoolAliases:
           - name: ca-cert
-            cmd: importcert
+            cmd: importkeystore
             sourcePath: "platform-ca/ca"
           - name: ssl-keypair
-            cmd: importcert
+            cmd: importkeystore 
             sourcePath: "ds/ssl-key-pair"
           - name: master-keypair
-            cmd: importcert
+            cmd: importkeystore  
             sourcePath: "ds/master-key-pair"
 
   - name: am-passwords

--- a/pkg/generator/certificate_test.go
+++ b/pkg/generator/certificate_test.go
@@ -11,21 +11,18 @@ import (
 )
 
 func TestKeyPair(t *testing.T) {
-	loadKeyRefs := func(testKeyMgr KeyMgr) error {
-		// loading references
-		rootCA := RootCA{
-			Cert: &Certificate{},
-			DistinguishedName: &v1alpha1.DistinguishedName{
-				CommonName: "foo",
-			},
-		}
-		rootCA.Generate()
-		rootCAData := make(map[string][]byte, 1)
-		rootCAData["foo/ca.pem"] = rootCA.Cert.CertPEM
-		rootCAData["foo/ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
-
-		return testKeyMgr.LoadReferenceData(rootCAData)
+	// loading references
+	rootCA := RootCA{
+		Name: "ca",
+		Cert: &Certificate{},
+		DistinguishedName: &v1alpha1.DistinguishedName{
+			CommonName: "foo",
+		},
 	}
+	rootCA.Generate()
+	rootCAData := make(map[string][]byte, 1)
+	rootCAData["foo/ca.pem"] = rootCA.Cert.CertPEM
+	rootCAData["foo/ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
 	key := &v1alpha1.KeyConfig{
 		Name: "myname",
 		Type: v1alpha1.KeyConfigTypeKeyPair,
@@ -75,15 +72,16 @@ func TestKeyPair(t *testing.T) {
 	// ref names
 	refNames, refKeys := testKeyMgr.References()
 	if len(refNames) != 2 || len(refKeys) != 2 {
-		t.Errorf("Expected to find exactly two referenc")
+		t.Errorf("Expected to find exactly two reference names and two keys")
 	}
+	// name of secret ref name
 	if refNames[0] != "foo" {
 		t.Errorf("Expected to find reName of foo, found %s", refNames[0])
 	}
-	if refKeys[0] != "ca-private.pem" {
-		t.Errorf("Expected to find reName of ca-private.pem, found %s", refKeys[0])
+	if refKeys[1] != "ca-private.pem" {
+		t.Errorf("Expected to find reName of ca-private.pem, found %s", refKeys[1])
 	}
-	if refKeys[1] != "ca.pem" {
+	if refKeys[0] != "ca.pem" {
 		t.Errorf("Expected to find reName of ca.pem, found %s", refKeys[0])
 	}
 	// // loading references
@@ -94,18 +92,6 @@ func TestKeyPair(t *testing.T) {
 	// rootCAData[0]["ca.pem"] = rootCA.Cert.CertPEM
 	// rootCAData[0]["ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
 	// err = testKeyMgr.LoadReferenceData(rootCAData)
-	if err := loadKeyRefs(testKeyMgr); err != nil {
-		t.Errorf("Expected no error %s", err)
-	}
-	if err != nil {
-		t.Fatalf("Expected no error, got: %+v", err)
-	}
-	if !regexp.MustCompile(`-----BEGIN CERTIFICATE-----`).Match(testKeyMgr.RootCA.Cert.CertPEM) {
-		t.Error("Expected '-----BEGIN CERTIFICATE-----' match, found none")
-	}
-	if !regexp.MustCompile(`BEGIN EC PRIVATE KEY`).Match(testKeyMgr.RootCA.Cert.PrivateKeyPEM) {
-		t.Error("Expected BEGIN EC PRIVATE KEY match, found none")
-	}
 	testKeyMgr.Cert.PrivateKeyPEM = []byte("foo bar")
 	testKeyMgr.Cert.CertPEM = []byte("foo bar")
 	if isEmpty := testKeyMgr.IsEmpty(); isEmpty {
@@ -118,7 +104,7 @@ func TestKeyPair(t *testing.T) {
 	if testGenKeyMgr == nil {
 		t.Errorf("tf")
 	}
-	loadKeyRefs(testGenKeyMgr)
+	testGenKeyMgr.LoadReferenceData(rootCAData)
 	if err := testGenKeyMgr.Generate(); err != nil {
 		t.Fatalf("Expected no error, got: %+v", err)
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -14,8 +14,9 @@ const (
 )
 
 var (
-	errRefPath   error = errors.New("reference path should be exactly a secret name and a data key")
-	errNoRefPath error = errors.New("no ref path found")
+	errRefPath    error = errors.New("reference path should be exactly a secret name and a data key")
+	errNoRefPath  error = errors.New("no ref path found")
+	errNoRefFound error = errors.New("no reference data found")
 )
 
 // KeyMgr an interface for managing secret data

--- a/pkg/generator/keytoolimportpassword.go
+++ b/pkg/generator/keytoolimportpassword.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/ForgeRock/secret-agent/api/v1alpha1"
@@ -31,8 +32,10 @@ func (kp *KeyToolImportPassword) References() ([]string, []string) {
 
 // LoadReferenceData loads data from references
 func (kp *KeyToolImportPassword) LoadReferenceData(data map[string][]byte) error {
-	if value, ok := data[kp.v1aliasConfig.SourcePath]; ok {
-		kp.refData = value
+	key := fmt.Sprintf("%s/%s", kp.refName, kp.refDataKey)
+	ok := true
+	if kp.refData, ok = data[key]; !ok {
+		return errors.Wrap(errNoRefFound, fmt.Sprintf("no data for %s", key))
 	}
 	return nil
 }

--- a/pkg/generator/keytoolimportstore.go
+++ b/pkg/generator/keytoolimportstore.go
@@ -1,0 +1,101 @@
+package generator
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// NewKeyToolImportKeystore created new
+func NewKeyToolImportKeystore(alias *v1alpha1.KeytoolAliasConfig) *KeyToolImportKeystore {
+	return &KeyToolImportKeystore{
+		v1aliasConfig: alias,
+	}
+}
+
+// KeyToolImportKeystore alias manager
+type KeyToolImportKeystore struct {
+	v1aliasConfig  *v1alpha1.KeytoolAliasConfig
+	refName        string
+	refDataKeys    []string
+	refPrivateData []byte
+	refPublicData  []byte
+	// TODO see #95
+	tempDir string
+}
+
+// References get list of refences needed for generated a alias
+func (k *KeyToolImportKeystore) References() ([]string, []string) {
+	var refDataKey string
+	k.refName, refDataKey = handleRefPath(k.v1aliasConfig.SourcePath)
+	k.refDataKeys = append(k.refDataKeys, fmt.Sprintf("%s.pem", refDataKey))
+	k.refDataKeys = append(k.refDataKeys, fmt.Sprintf("%s-private.pem", refDataKey))
+
+	return []string{k.refName, k.refName}, k.refDataKeys
+}
+
+// LoadReferenceData loads data from references
+func (k *KeyToolImportKeystore) LoadReferenceData(data map[string][]byte) error {
+	ok := true
+	pubName := fmt.Sprintf("%s/%s", k.refName, k.refDataKeys[0])
+	privName := fmt.Sprintf("%s/%s", k.refName, k.refDataKeys[1])
+	if k.refPublicData, ok = data[pubName]; !ok {
+		return errors.Wrap(errNoRefFound, fmt.Sprintf("no data for %s", pubName))
+	}
+	if k.refPrivateData, ok = data[privName]; !ok {
+		return errors.Wrap(errNoRefFound, fmt.Sprintf("no data for %s", privName))
+	}
+	return nil
+}
+
+// Generate creates keytool password alias entry
+func (k *KeyToolImportKeystore) Generate(baseCmd cmdRunner) error {
+	var err error = nil
+	k.tempDir, err = ioutil.TempDir("", "keystore-*")
+	defer os.RemoveAll(k.tempDir)
+	// write to file
+	publicPath := filepath.Join(k.tempDir, "temp.crt")
+	privatePath := filepath.Join(k.tempDir, "temp.key")
+	opensslStore := filepath.Join(k.tempDir, "openssl.p12")
+	err = ioutil.WriteFile(publicPath, k.refPublicData, 0600)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(privatePath, k.refPrivateData, 0600)
+	if err != nil {
+		return err
+	}
+	opensslArgs := []string{"pkcs12",
+		"-export",
+		"-in", publicPath,
+		"-inkey", privatePath,
+		"-out", opensslStore,
+		"-name", k.v1aliasConfig.Name,
+		"-passout", "pass:changeit",
+	}
+	opensslCmd := exec.Command(*opensslPath, opensslArgs...)
+	output, err := opensslCmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, string(output))
+	}
+	cmd := "-importkeystore"
+	importArgs := []string{
+		"-srckeystore", opensslStore,
+		"-srcstoretype", "pkcs12",
+		"-srcstorepass", "changeit",
+		"-srcalias", k.v1aliasConfig.Name,
+		"-destalias", k.v1aliasConfig.Name,
+		"-noprompt",
+	}
+	execCmd := baseCmd(cmd, importArgs)
+	output, err = execCmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, string(output))
+	}
+	return nil
+}

--- a/pkg/generator/keytoolimportstore_test.go
+++ b/pkg/generator/keytoolimportstore_test.go
@@ -1,0 +1,90 @@
+package generator
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+)
+
+func TestImportKeyStore(t *testing.T) {
+	rootCA, err := makeTestNewRootCA(t)
+	if err != nil {
+		t.Error(err)
+	}
+	rootCA.Generate()
+	importSpec := &v1alpha1.KeyConfig{
+		Name: "testConfig",
+		Type: "keytool",
+		Spec: &v1alpha1.KeySpec{
+			StorePassPath: "storepass/pass",
+			StoreType:     "pkcs12",
+			KeyPassPath:   "keypass/pass",
+			KeytoolAliases: []*v1alpha1.KeytoolAliasConfig{
+				{
+					Name:       "testimportkeystore",
+					Cmd:        "importkeystore",
+					SourcePath: "testConfig/ca",
+				},
+			},
+		},
+	}
+	keyToolMgr, err := NewKeyTool(importSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	refNames, refKeys := keyToolMgr.References()
+	if len(refNames) != 4 {
+		t.Errorf("expected exactly two secrets")
+
+	}
+	if len(refKeys) != 4 {
+		t.Errorf("expected exactly two secrets")
+
+	}
+	// setup rootca data
+	rootCAData := make(map[string][]byte, 2)
+	rootCAData["testConfig/ca.pem"] = rootCA.Cert.CertPEM
+	rootCAData["testConfig/ca-private.pem"] = rootCA.Cert.PrivateKeyPEM
+	rootCAData["keypass/pass"] = []byte("myvalue")
+	rootCAData["storepass/pass"] = []byte("myvalue")
+
+	keyToolMgr.LoadReferenceData(rootCAData)
+
+	err = keyToolMgr.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check temp doesn't exist
+	baseArgs := []string{
+		"-storetype", string(keyToolMgr.V1Spec.StoreType),
+		"-storepass", keyToolMgr.storePassValue,
+		"-keypass", keyToolMgr.keyPassValue,
+		"-keystore", keyToolMgr.storePath,
+	}
+	baseCmd := execCommand(*keytoolPath, baseArgs)
+	args := []string{
+		"-alias", "testimportkeystore",
+	}
+	if _, err := os.Stat(keyToolMgr.storePath); !os.IsNotExist(err) {
+		t.Error("expected keyToolMgr to cleanup store but didn't")
+	}
+	// TODO this for some reason wont cast down to it's concrete type
+	// keyStoreImport := keyToolMgr.aliasMgrs[0]
+	// if _, err := os.Stat(keyStoreImport.(KeyToolImportKeystore).tempDir); !os.IsNotExist(err) {
+	// 	t.Error("expected keyToolMgr to cleanup store but didn't")
+	// }
+	ioutil.WriteFile(keyToolMgr.storePath, keyToolMgr.storeBytes, 0600)
+	defer os.RemoveAll(keyToolMgr.storePath)
+	cmd := baseCmd("-list", args)
+	results, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(string(results))
+	}
+	if !strings.Contains(string(results), string(importSpec.Spec.KeytoolAliases[0].Name)) {
+		t.Errorf("Expected Alias %s to exist but found: \n %s", string(keyToolMgr.Name), string(results))
+	}
+}

--- a/pkg/generator/rootca_test.go
+++ b/pkg/generator/rootca_test.go
@@ -71,18 +71,18 @@ func TestRootCA(t *testing.T) {
 
 	// test to kubernetes
 	rootCA.ToKubernetes(testSecret)
-	if !bytes.Equal(testSecret.Data["ca.pem"], rootCA.Cert.CertPEM) {
+	if !bytes.Equal(testSecret.Data[rootCA.publicKeyName], rootCA.Cert.CertPEM) {
 		t.Error("expected secret data and root ca pem to match")
 	}
-	if !bytes.Equal(testSecret.Data["ca-private.pem"], rootCA.Cert.PrivateKeyPEM) {
+	if !bytes.Equal(testSecret.Data[rootCA.privateKeyName], rootCA.Cert.PrivateKeyPEM) {
 		t.Error("expected seceret data and ca private pem to match")
 	}
 
 	// test load data
 	testCAPEM := []byte("this is public")
 	testCAPrivatePEM := []byte("this is private")
-	testSecret.Data["ca.pem"] = testCAPEM
-	testSecret.Data["ca-private.pem"] = testCAPrivatePEM
+	testSecret.Data[rootCA.publicKeyName] = testCAPEM
+	testSecret.Data[rootCA.privateKeyName] = testCAPrivatePEM
 	rootCA.LoadFromData(testSecret.Data)
 	if !bytes.Equal(testCAPEM, rootCA.Cert.CertPEM) {
 		t.Error("expected secret data and root ca pem to match")

--- a/pkg/generator/truststore.go
+++ b/pkg/generator/truststore.go
@@ -91,7 +91,7 @@ func (ts *TrustStore) EnsureSecretManager(context context.Context, config *v1alp
 func (ts *TrustStore) Generate() error {
 	systemBundle, err := ioutil.ReadFile("/etc/ssl/certs/ca-certificates.crt")
 	if err != nil {
-		return errors.WithMessage(err, "error occured when attempting to pull system trust store")
+		return errors.WithMessage(err, "error occured when attempting to read system trust store")
 	}
 	pemBytes := append(ts.Value, systemBundle...)
 	pemBytes = append(pemBytes, ts.refData...)

--- a/pkg/generator/truststore_test.go
+++ b/pkg/generator/truststore_test.go
@@ -20,7 +20,7 @@ func TestTrustStore(t *testing.T) {
 		Name: "myname",
 		Type: v1alpha1.KeyConfigTypeTrustStore,
 		Spec: &v1alpha1.KeySpec{
-			TruststoreImportPaths: []string{"testconfig/ca"},
+			TruststoreImportPaths: []string{"testConfig/ca"},
 		},
 	}
 	tsMgr, err := NewTrustStore(key)
@@ -32,7 +32,7 @@ func TestTrustStore(t *testing.T) {
 	}
 	tsMgr.References()
 	tsMgr.LoadReferenceData(map[string][]byte{
-		"testconfig/ca.pem": testSecret.Data["ca.pem"],
+		"testConfig/ca.pem": testSecret.Data[rootCA.publicKeyName],
 	})
 	tsMgr.Generate()
 	parsed, err := pkcs12.DecodeTrustStore(tsMgr.Value, "changeit")


### PR DESCRIPTION
RootCA now serializes itself to secrets the key of `name` e.g: 
```
 - name: platform-ca
      keys:
>>    - name: ca
```
Is stored in the secret platform-ca as `ca.pem` and `ca-private.pem` 