### PR TITLE
Add support for AWS secret manager

### DIFF
--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -164,15 +164,26 @@ const (
 	KeytoolCmdImportkeystore KeytoolCmd = "importkeystore"
 )
 
+// SecretManagerCredentialKeyName Specifies name of the secret key to be referenced
+type SecretManagerCredentialKeyName string
+
+// SecretManagerCredentialKeyName Type Strings
+const (
+	SecretsManagerGoogleApplicationCredentials SecretManagerCredentialKeyName = "GOOGLE_CREDENTIALS_JSON"
+	SecretsManagerAwsAccessKeyID               SecretManagerCredentialKeyName = "AWS_ACCESS_KEY_ID"
+	SecretsManagerAwsSecretAccessKey           SecretManagerCredentialKeyName = "AWS_SECRET_ACCESS_KEY"
+)
+
 // AppConfig is the configuration for the forgeops-secrets application
 type AppConfig struct {
 	// +kubebuilder:validation:Required
 	CreateKubernetesObjects bool `json:"createKubernetesObjects"`
 	// +kubebuilder:validation:Required
-	SecretsManager SecretsManager `json:"secretsManager"`
-	GCPProjectID   string         `json:"gcpProjectID,omitempty"`
-	AWSRegion      string         `json:"awsRegion,omitempty"`
-	AzureVaultName string         `json:"azureVaultName,omitempty"`
+	SecretsManager        SecretsManager `json:"secretsManager"`
+	CredentialsSecretName string         `json:"credentialsSecretName,omitempty"`
+	GCPProjectID          string         `json:"gcpProjectID,omitempty"`
+	AWSRegion             string         `json:"awsRegion,omitempty"`
+	AzureVaultName        string         `json:"azureVaultName,omitempty"`
 
 	// Optional number of times the operator will attempt to generate secrets. Defaults to 3
 	MaxRetries *int `json:"maxRetries,omitempty"`

--- a/api/v1alpha1/secretagentconfiguration_webhook.go
+++ b/api/v1alpha1/secretagentconfiguration_webhook.go
@@ -136,6 +136,11 @@ func ConfigurationStructLevelValidator(sl validator.StructLevel) {
 	config := sl.Current().Interface().(SecretAgentConfigurationSpec)
 
 	// AppConfig
+	if config.AppConfig.SecretsManager != SecretsManagerNone {
+		if config.AppConfig.CredentialsSecretName == "" {
+			sl.ReportError(config.AppConfig.CredentialsSecretName, "credentialSecretName", "CredentialSecretName", "needCredentialSecretName", "")
+		}
+	}
 	switch config.AppConfig.SecretsManager {
 	case SecretsManagerGCP:
 		if config.AppConfig.GCPProjectID == "" {

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -63,6 +63,8 @@ spec:
                   type: integer
                 createKubernetesObjects:
                   type: boolean
+                credentialsSecretName:
+                  type: string
                 gcpProjectID:
                   type: string
                 maxRetries:

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -7,8 +7,10 @@ spec:
   appConfig:
     createKubernetesObjects: true
     secretsManager: none  # none, AWS, or GCP
+    # credentialsSecretName: cloud-credentials
     # awsRegion: example-region
     # azureVaultName: example-vault
+    # gcpProjectID: example-project
   secrets:
   - name: sms-transport-key
     keys:

--- a/config/samples/secretManager/cloud-credentials.yaml
+++ b/config/samples/secretManager/cloud-credentials.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cloud-credentials
+data:
+  # AZURE_ACCOUNT_KEY:       # Update if using Azure Secret Manager
+  # AZURE_ACCOUNT_NAME:      # Update if using Azure Secret Manager
+  # AWS_ACCESS_KEY_ID:       # OPTIONAL: Update if using AWS Secret Manager
+  # AWS_SECRET_ACCESS_KEY:   # OPTIONAL: Update if using AWS Secret Manager
+  # GOOGLE_CREDENTIALS_JSON: # Update if using GCP Secret Manager

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/aws/aws-sdk-go v1.34.15
 	github.com/go-logr/logr v0.1.0
 	github.com/go-playground/validator/v10 v10.2.0
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.34.15 h1:+4xW7qt/rVPClUKq/5i8SMhFRTI/3uzVDIb0x5i9h9o=
+github.com/aws/aws-sdk-go v1.34.15/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -185,6 +187,7 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -262,6 +265,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -239,10 +239,10 @@ func (kp *CertKeyPair) LoadFromData(data map[string][]byte) {
 
 // IsEmpty checks if CertKeyPair has any useable
 func (kp *CertKeyPair) IsEmpty() bool {
-	if kp.Cert.CertPEM == nil {
+	if kp.Cert.CertPEM == nil || kp.Cert.PrivateKeyPEM == nil {
 		return true
 	}
-	if kp.Cert.PrivateKeyPEM == nil {
+	if len(kp.Cert.CertPEM) == 0 || len(kp.Cert.PrivateKeyPEM) == 0 {
 		return true
 	}
 	return false

--- a/pkg/generator/keytool.go
+++ b/pkg/generator/keytool.go
@@ -170,7 +170,7 @@ func (kt *KeyTool) LoadReferenceData(data map[string][]byte) error {
 
 // LoadSecretFromManager load keystore from secrete manager
 func (kt *KeyTool) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
-	return nil
+	return errors.New("LoadSecretFromManager not implemented for KeyTool")
 }
 
 // EnsureSecretManager adds keystore to secret manager

--- a/pkg/generator/truststore.go
+++ b/pkg/generator/truststore.go
@@ -79,7 +79,7 @@ func (ts *TrustStore) LoadReferenceData(data map[string][]byte) error {
 
 // LoadSecretFromManager load from secrete manager
 func (ts *TrustStore) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
-	return nil
+	return errors.New("LoadSecretFromManager not implemented for TrustStore")
 }
 
 // EnsureSecretManager adds  to secret manager


### PR DESCRIPTION
1. Add support for AWS secret manager
1. Fix bug in isEmpty for KeyPairs
1. Credentials to access the secret mgr are now passed through a secret ref in the SAC using `credentialsSecretName`
1. Retry reconcile loop if error with secret manager.
1. Temporary bypass secret manager for keytool and truststore #80 #111


closes #109, closes #49