### PR TITLE
Ability to select the source NS for cloud creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `secret-agent` expects credentials to be discoverable via standard [AWS mech
 
 Refer to [AWS documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_overview.html) for instructions on how to obtain credentials and grant necessary permissions to access the AWS Secrets Manager. The `secret-agent` needs to access read/write secrets. This can be achieved by allowing access to the `arn:aws:iam::aws:policy/SecretsManagerReadWrite` AWS managed policy.
 
-Even though the recommended way to obtain credentials is to use the EC2 Instance Metadata service, it is possible to provide custom credentials via a Kubernetes secret. The secret reference is provided in the SAC in `spec.appConfig.credentialsSecretName`. The referenced Kubernetes secret must be present in the same namespace as the SAC.
+Even though the recommended way to obtain credentials is to use the EC2 Instance Metadata service, it is possible to provide custom credentials via a Kubernetes secret. The secret reference is provided in the SAC in `spec.appConfig.credentialsSecretName`. In the default `secret-agent` deployment, the operator will look for a secret with the provided name in the operator's own namespace. The user can specify a different namespace by setting the argument `--cloud-secrets-namespace=[NS_NAME]`. If this argument is omitted, the operator's default behavior is to fetch the credentials from the same namespace as the SAC.
 
 Once these credentials are posted to a Kubernetes secret, the next step is to configure the AWS Secret Manager using the `SecretAgentConfiguration`.
 
@@ -107,7 +107,7 @@ The `secret-agent` expects credentials to be discoverable via standard [GCP mech
 
 Please refer to the [GCP Documentation](https://cloud.google.com/secret-manager/docs/reference/libraries?hl=nl#cloud-console) for instructions on how to create a service account with the necessary permissions to access the GCP Secrets Manager. The `secret-agent` needs access to read/write secrets. This can be achieved by assigning the `Secret Manager Admin` role to the service account provided.
 
-The credentials are provided to the operator using a kubernetes secret under the `GOOGLE_CREDENTIALS_JSON` data key. The name of this secret is provided in `spec.appConfig.credentialsSecretName`. The referenced Kubernetes secret must be present in the same namespace as the SAC.
+The credentials are provided to the operator using a kubernetes secret under the `GOOGLE_CREDENTIALS_JSON` data key. The name of this secret is provided in `spec.appConfig.credentialsSecretName`. In the default `secret-agent` deployment, the operator will look for a secret with the provided name in the operator's own namespace. The user can specify a different namespace by setting the argument `--cloud-secrets-namespace=[NS_NAME]`. If this argument is omitted, the operator's default behavior is to fetch the credentials from the same namespace as the SAC.
 
 Once these credentials are posted to a Kubernetes secret, the next step is to configure the GCP Secret Manager using the `SecretAgentConfiguration`.
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,8 @@ spec:
         - --webhook-service-name=$(SERVICE_NAME)
         - --webhook-secret-name=webhook-server-cert
         - --validating-webhook-name=$(VALIDATING_WEBHOOK_CONFIGURATION_NAME)
-        - --mutating-webhook-name=$(MUTATING_WEBHOOK_CONFIGURATION_NAME) 
+        - --mutating-webhook-name=$(MUTATING_WEBHOOK_CONFIGURATION_NAME)
+        - --cloud-secrets-namespace=$(SERVICE_NAMESPACE)
         image: controller:latest
         name: manager
         ports:

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	var certDir string
 	var debug bool
 	var lvl uberzap.AtomicLevel
+	var cloudSecretsNamespace string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -58,6 +59,9 @@ func main() {
 	flag.StringVar(&certDir, "cert-dir", "/tmp/k8s-webhook-server/serving-certs",
 		"Directory where to store/read the webhook certs. Defaults to /tmp/k8s-webhook-server/serving-certs")
 	flag.BoolVar(&debug, "debug", false, "Set to true to enable debug")
+	flag.StringVar(&cloudSecretsNamespace, "cloud-secrets-namespace", "",
+		"Namespace where the cloud credentials secrets are located. Defaults to the SAC namespace")
+
 	flag.Parse()
 	if debug {
 		lvl = uberzap.NewAtomicLevelAt(uberzap.DebugLevel)
@@ -80,9 +84,10 @@ func main() {
 	}
 
 	if err = (&controllers.SecretAgentConfigurationReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("SecretAgentConfiguration"),
-		Scheme: mgr.GetScheme(),
+		Client:                mgr.GetClient(),
+		Log:                   ctrl.Log.WithName("controllers").WithName("SecretAgentConfiguration"),
+		Scheme:                mgr.GetScheme(),
+		CloudSecretsNamespace: cloudSecretsNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SecretAgentConfiguration")
 		os.Exit(1)


### PR DESCRIPTION
1. Users can force the NS the operator uses to source cloud creds
1. The NS is provided using ` --cloud-secrets-namespace` runtime arg.
1. If the arg is omitted, it assumes the creds NS is the same as the SAC
1. The sample deployment uses the same NS as the operator by default
1. Update the README.md to account for these changes.

Closes #133