### PR TITLE
Add support for GCP workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ spec:
 
 _note:_ Azure's API response time on Key Vault is long and will delay the creation of secrets. It might be beneficial to deploy a SAC before long before deploying an application if use Azure Key Vault
 
-The `secret-agent` uses credentials which are available using two different methods: Azure Managed Identities or explicit credentials. Both are configured in the secret that's referenced in the SAC spec `spec.appConfig.credentialsSecretName`. Example Azure Configuration for a SAC:
+The `secret-agent` uses credentials which are available using two different methods: Azure Managed Identities (recommended for Azure deployemnts) or explicit credentials. Explicit credentials are configured in a secret referenced in the SAC spec `spec.appConfig.credentialsSecretName`. Example Azure Configuration for a SAC:
 
 ```yaml
 apiVersion: secret-agent.secrets.forgerock.io/v1alpha1
@@ -179,12 +179,14 @@ metadata:
 spec:
   appConfig:
     createKubernetesObjects: true
-    credentialsSecretName: cloud-credentials
+    credentialsSecretName: cloud-credentials [** optional**]
     secretsManager: Azure
-    azureVaultName: secret-agent-vault 
+    azureVaultName: secret-agent-vault
 ```
 
-If the `credentialsSecretName` secret has a data key `AZURE_MANAGED_ID` set to `"true"` the operator's Azure client authentication will [be loaded by Azure](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity). The credentials may explicitly be set in the `credentialsSecretName` secret as well. It's recommended to use Azure Managed Identity. The service principle associated with the keys will need the role `Key Vault Secrets Officer` when using an RBAC policy based Key Vault.
+If no secret is provided in `credentialsSecretName`, the operator's Azure client will attempt to authenticate using managed identities. For more information, see Azure's [documentation](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity). This is the recommended configuration for deployments in Azure's AKS.
+
+Otherwise, the credentials may be explicitly set in the `credentialsSecretName` secret. The service principle associated with the keys will need the role `Key Vault Secrets Officer` when using an RBAC policy based Key Vault.
 
 Example credentials secret:
 
@@ -198,8 +200,6 @@ data:
   # AZURE_TENANT_ID: # OPTIONAL: Update if using Azure Key Vault
   # AZURE_CLIENT_ID: # OPTIONAL: Update if using Azure Key Vault
   # AZURE_CLIENT_SECRET: # OPTIONAL: Update if using Azure Key Vault
-  # -- or --
-  AZURE_MANAGED_ID: "true" # OPTIONAL: set to true if Azure using Azure Managed Ids
 ```
 
 ### Importing your own secrets

--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -174,7 +174,6 @@ const (
 	SecretsManagerGoogleApplicationCredentials SecretManagerCredentialKeyName = "GOOGLE_CREDENTIALS_JSON"
 	SecretsManagerAwsAccessKeyID               SecretManagerCredentialKeyName = "AWS_ACCESS_KEY_ID"
 	SecretsManagerAwsSecretAccessKey           SecretManagerCredentialKeyName = "AWS_SECRET_ACCESS_KEY"
-	SecretsManagerAzureManagedID               SecretManagerCredentialKeyName = "AZURE_MANAGED_ID"
 	SecretsManagerAzureTenantID                SecretManagerCredentialKeyName = "AZURE_TENANT_ID"
 	SecretsManagerAzureClientID                SecretManagerCredentialKeyName = "AZURE_CLIENT_ID"
 	SecretsManagerAzureClientSecret            SecretManagerCredentialKeyName = "AZURE_CLIENT_SECRET"

--- a/api/v1alpha1/secretagentconfiguration_webhook.go
+++ b/api/v1alpha1/secretagentconfiguration_webhook.go
@@ -131,12 +131,6 @@ func (r *SecretAgentConfiguration) ValidateSecretConfiguration() error {
 func ConfigurationStructLevelValidator(sl validator.StructLevel) {
 	config := sl.Current().Interface().(SecretAgentConfigurationSpec)
 
-	// AppConfig
-	if config.AppConfig.SecretsManager == SecretsManagerAzure {
-		if config.AppConfig.CredentialsSecretName == "" {
-			sl.ReportError(config.AppConfig.CredentialsSecretName, "credentialSecretName", "CredentialSecretName", "needCredentialSecretName", "")
-		}
-	}
 	switch config.AppConfig.SecretsManager {
 	case SecretsManagerGCP:
 		if config.AppConfig.GCPProjectID == "" {

--- a/api/v1alpha1/secretagentconfiguration_webhook.go
+++ b/api/v1alpha1/secretagentconfiguration_webhook.go
@@ -132,7 +132,7 @@ func ConfigurationStructLevelValidator(sl validator.StructLevel) {
 	config := sl.Current().Interface().(SecretAgentConfigurationSpec)
 
 	// AppConfig
-	if config.AppConfig.SecretsManager != SecretsManagerNone {
+	if config.AppConfig.SecretsManager == SecretsManagerAzure {
 		if config.AppConfig.CredentialsSecretName == "" {
 			sl.ReportError(config.AppConfig.CredentialsSecretName, "credentialSecretName", "CredentialSecretName", "needCredentialSecretName", "")
 		}

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,6 @@ kind: ServiceAccount
 metadata:
   name: manager-service-account
   namespace: system
+  ## If using GCP workload identity, annotate the service account with the gsa-name
+  # annotations:
+  #   iam.gke.io/gcp-service-account: secret-manager@engineering-devops.iam.gserviceaccount.com

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -13,7 +13,7 @@ spec:
     # If secrets don't exist, they are generated and stored in the manager.
     secretsManager: none # none, AWS, Azure, or GCP
     # secretsManagerPrefix: "prefix"
-    ## credentials for cloud provider (optional for AWS and GCP)
+    ## credentials for cloud provider (optional. see README.md)
     # credentialsSecretName: cloud-credentials
     ## When running on GCP, specify a ProjectID
     # gcpProjectID: sample-project-id

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -12,12 +12,16 @@ spec:
     # A cloud provider's secret manager is the source of truth.
     # If secrets don't exist, they are generated and stored in the manager.
     secretsManager: none # none, AWS, Azure, or GCP
-    # When running on AWS, specify a region
-    # awsRegion: example-region
-    # When running on Azure, specify a vault
-    # azureVaultName: secret-agent-test
-    # credentials for cloud provider
+    # secretsManagerPrefix: "prefix"
+    ## credentials for cloud provider (optional for AWS and GCP)
     # credentialsSecretName: cloud-credentials
+    ## When running on GCP, specify a ProjectID
+    # gcpProjectID: sample-project-id
+    ## When running on AWS, specify a region
+    # awsRegion: example-region
+    ## When running on Azure, specify a vault
+    # azureVaultName: secret-agent-test
+
   # Start of secrets array
 
   # In this YAML file, the "secrets" key defines Kubernetes secret objects managed by the

--- a/config/samples/secretManager/cloud-credentials.yaml
+++ b/config/samples/secretManager/cloud-credentials.yaml
@@ -7,7 +7,6 @@ data:
   # AZURE_TENANT_ID: # OPTIONAL: Update if using Azure Keyvault 
   # AZURE_CLIENT_ID: # OPTIONAL: Update if using Azure Keyvault 
   # AZURE_CLIENT_SECRET: # OPTIONAL: Update if using Azure Keyvault 
-  # AZURE_MANAGED_ID: # OPTIONAL: set to true if Azure using Azure Managed Ids
   # AWS_ACCESS_KEY_ID:       # OPTIONAL: Update if using AWS Secret Manager
   # AWS_SECRET_ACCESS_KEY:   # OPTIONAL: Update if using AWS Secret Manager
   # GOOGLE_CREDENTIALS_JSON: # Update if using GCP Secret Manager

--- a/controllers/secretagentconfiguration_controller.go
+++ b/controllers/secretagentconfiguration_controller.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -438,16 +437,6 @@ func manageCloudCredentials(secManager v1alpha1.SecretsManager, secObject *corev
 			}
 		}
 	case v1alpha1.SecretsManagerAzure:
-		// Azure managed identity - no direct credentials needed
-		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAzureManagedID)]; ok {
-			enabled, err := strconv.ParseBool(string(keyValue))
-			if err != nil {
-				return err
-			}
-			if enabled {
-				return nil
-			}
-		}
 		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAzureTenantID)]; ok {
 			if err := os.Setenv("AZURE_TENANT_ID", string(keyValue)); err != nil {
 				return err

--- a/controllers/secretagentconfiguration_controller.go
+++ b/controllers/secretagentconfiguration_controller.go
@@ -84,7 +84,8 @@ func (reconciler *SecretAgentConfigurationReconciler) Reconcile(req ctrl.Request
 	defer func() { watchOwnedObjects = true }()
 	log.V(1).Info("** Reconcile loop start **")
 
-	if instance.Spec.AppConfig.SecretsManager != v1alpha1.SecretsManagerNone {
+	if instance.Spec.AppConfig.SecretsManager != v1alpha1.SecretsManagerNone &&
+		instance.Spec.AppConfig.CredentialsSecretName != "" {
 		var dir string
 		var cloudCredNS string
 


### PR DESCRIPTION
1. Add support for GCP workload identity
1. Update README with new steps to enable workload identity
1. Add GCP secret manager fields to the sample SAC.
1. Make "managed identities" the default authentication method for Azure AKS

Closes #132