### PR TITLE
Remove `caBundle` from webhook configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ clean: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	# Remove "caBuncle: Cg==" from the webhook config. controller-gen generates the manifests with a placeholder
+	awk '!/caBundle:/' config/webhook/manifests.yaml > t && mv t config/webhook/manifests.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -7,7 +7,6 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -33,7 +32,6 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system


### PR DESCRIPTION
1. Remove `caBundle` from webhook conf to avoid accidental overwrite

Closes #142