### PR TITLE
Refactor Secret Manager Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.4.1
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,9 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -281,6 +283,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -359,6 +362,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -645,6 +649,7 @@ google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zim
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -156,16 +156,16 @@ func (kp *CertKeyPair) References() ([]string, []string) {
 }
 
 // LoadSecretFromManager populates RootCA data from secret manager
-func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	publicPemKeyFmt := fmt.Sprintf("%s_%s_%s.pem", namespace, secretName, kp.Name)
 	privatePemKeyFmt := fmt.Sprintf("%s_%s_%s-private.pem", namespace, secretName, kp.Name)
 
-	kp.Cert.CertPEM, err = secretsmanager.LoadSecret(ctx, config, publicPemKeyFmt)
+	kp.Cert.CertPEM, err = sm.LoadSecret(ctx, publicPemKeyFmt)
 	if err != nil {
 		return err
 	}
-	kp.Cert.PrivateKeyPEM, err = secretsmanager.LoadSecret(ctx, config, privatePemKeyFmt)
+	kp.Cert.PrivateKeyPEM, err = sm.LoadSecret(ctx, privatePemKeyFmt)
 	if err != nil {
 		return err
 	}
@@ -173,15 +173,15 @@ func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, config *v1alph
 }
 
 // EnsureSecretManager populates secrete manager from RootCA data
-func (kp *CertKeyPair) EnsureSecretManager(ctx context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (kp *CertKeyPair) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	publicPemKeyFmt := fmt.Sprintf("%s_%s_%s.pem", namespace, secretName, kp.Name)
 	privatePemKeyFmt := fmt.Sprintf("%s_%s_%s-private.pem", namespace, secretName, kp.Name)
-	err = secretsmanager.EnsureSecret(ctx, config, publicPemKeyFmt, kp.Cert.CertPEM)
+	err = sm.EnsureSecret(ctx, publicPemKeyFmt, kp.Cert.CertPEM)
 	if err != nil {
 		return err
 	}
-	err = secretsmanager.EnsureSecret(ctx, config, privatePemKeyFmt, kp.Cert.PrivateKeyPEM)
+	err = sm.EnsureSecret(ctx, privatePemKeyFmt, kp.Cert.PrivateKeyPEM)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/keytool.go
+++ b/pkg/generator/keytool.go
@@ -172,21 +172,21 @@ func (kt *KeyTool) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager  populates keytool data from secret manager
-func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	keyToolFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, kt.Name)
 	storePassFmt := fmt.Sprintf("%s_%s_%s_storepass", namespace, secretName, kt.Name)
 	keyPasslFmt := fmt.Sprintf("%s_%s_%s_keypass", namespace, secretName, kt.Name)
-	kt.storeBytes, err = secretsmanager.LoadSecret(ctx, config, keyToolFmt)
+	kt.storeBytes, err = sm.LoadSecret(ctx, keyToolFmt)
 	if err != nil {
 		return err
 	}
-	storePassValueBytes, err := secretsmanager.LoadSecret(ctx, config, storePassFmt)
+	storePassValueBytes, err := sm.LoadSecret(ctx, storePassFmt)
 	kt.storePassValue = string(storePassValueBytes)
 	if err != nil {
 		return err
 	}
-	keyPassValueBytes, err := secretsmanager.LoadSecret(ctx, config, keyPasslFmt)
+	keyPassValueBytes, err := sm.LoadSecret(ctx, keyPasslFmt)
 	kt.keyPassValue = string(keyPassValueBytes)
 	if err != nil {
 		return err
@@ -195,22 +195,22 @@ func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, config *v1alpha1.A
 }
 
 // EnsureSecretManager adds keytool to secret manager
-func (kt *KeyTool) EnsureSecretManager(ctx context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (kt *KeyTool) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 
 	var err error
 	keyToolFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, kt.Name)
 	storePassFmt := fmt.Sprintf("%s_%s_%s_storepass", namespace, secretName, kt.Name)
 	keyPasslFmt := fmt.Sprintf("%s_%s_%s_keypass", namespace, secretName, kt.Name)
 
-	err = secretsmanager.EnsureSecret(ctx, config, keyToolFmt, kt.storeBytes)
+	err = sm.EnsureSecret(ctx, keyToolFmt, kt.storeBytes)
 	if err != nil {
 		return err
 	}
-	err = secretsmanager.EnsureSecret(ctx, config, storePassFmt, []byte(kt.storePassValue))
+	err = sm.EnsureSecret(ctx, storePassFmt, []byte(kt.storePassValue))
 	if err != nil {
 		return err
 	}
-	err = secretsmanager.EnsureSecret(ctx, config, keyPasslFmt, []byte(kt.keyPassValue))
+	err = sm.EnsureSecret(ctx, keyPasslFmt, []byte(kt.keyPassValue))
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/literal.go
+++ b/pkg/generator/literal.go
@@ -32,10 +32,10 @@ func (literal *Literal) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates Literal data from secret manager
-func (literal *Literal) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (literal *Literal) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
-	literal.Value, err = secretsmanager.LoadSecret(context, config, literalFmt)
+	literal.Value, err = sm.LoadSecret(context, literalFmt)
 	if err != nil {
 		return err
 	}
@@ -43,10 +43,10 @@ func (literal *Literal) LoadSecretFromManager(context context.Context, config *v
 }
 
 // EnsureSecretManager populates secrets manager from Literal data
-func (literal *Literal) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (literal *Literal) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
-	err = secretsmanager.EnsureSecret(context, config, literalFmt, literal.Value)
+	err = sm.EnsureSecret(context, literalFmt, literal.Value)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/password.go
+++ b/pkg/generator/password.go
@@ -35,10 +35,10 @@ func (pwd *Password) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates Password data from secret manager
-func (pwd *Password) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (pwd *Password) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	pwdFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, pwd.Name)
-	pwd.Value, err = secretsmanager.LoadSecret(context, config, pwdFmt)
+	pwd.Value, err = sm.LoadSecret(context, pwdFmt)
 	if err != nil {
 		return err
 	}
@@ -46,10 +46,10 @@ func (pwd *Password) LoadSecretFromManager(context context.Context, config *v1al
 }
 
 // EnsureSecretManager populates secrets manager from Password data
-func (pwd *Password) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (pwd *Password) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	pwdFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, pwd.Name)
-	err = secretsmanager.EnsureSecret(context, config, pwdFmt, pwd.Value)
+	err = sm.EnsureSecret(context, pwdFmt, pwd.Value)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/ssh.go
+++ b/pkg/generator/ssh.go
@@ -35,16 +35,16 @@ func (ssh *SSH) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates SSH data from secret manager
-func (ssh *SSH) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (ssh *SSH) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	var err error
 	sshPrivateFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, ssh.Name)
 	sshPublicFmt := fmt.Sprintf("%s_%s_%s.pub", namespace, secretName, ssh.Name)
 
-	ssh.PrivateKeyPEM, err = secretsmanager.LoadSecret(context, config, sshPrivateFmt)
+	ssh.PrivateKeyPEM, err = sm.LoadSecret(context, sshPrivateFmt)
 	if err != nil {
 		return err
 	}
-	ssh.PublicKeyPEM, err = secretsmanager.LoadSecret(context, config, sshPublicFmt)
+	ssh.PublicKeyPEM, err = sm.LoadSecret(context, sshPublicFmt)
 	if err != nil {
 		return err
 	}
@@ -52,15 +52,15 @@ func (ssh *SSH) LoadSecretFromManager(context context.Context, config *v1alpha1.
 }
 
 // EnsureSecretManager populates secrets manager from SSH data
-func (ssh *SSH) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (ssh *SSH) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	sshPrivateFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, ssh.Name)
 	sshPublicFmt := fmt.Sprintf("%s_%s_%s.pub", namespace, secretName, ssh.Name)
 
-	if err := secretsmanager.EnsureSecret(context, config, sshPrivateFmt, ssh.PrivateKeyPEM); err != nil {
+	if err := sm.EnsureSecret(context, sshPrivateFmt, ssh.PrivateKeyPEM); err != nil {
 		return err
 	}
 
-	if err := secretsmanager.EnsureSecret(context, config, sshPublicFmt, ssh.PublicKeyPEM); err != nil {
+	if err := sm.EnsureSecret(context, sshPublicFmt, ssh.PublicKeyPEM); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/generator/truststore.go
+++ b/pkg/generator/truststore.go
@@ -13,6 +13,7 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 
 	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+	"github.com/ForgeRock/secret-agent/pkg/secretsmanager"
 )
 
 func parseRootChain(bundle []byte) []*x509.Certificate {
@@ -77,13 +78,13 @@ func (ts *TrustStore) LoadReferenceData(data map[string][]byte) error {
 	return nil
 }
 
-// LoadSecretFromManager load from secrete manager
-func (ts *TrustStore) LoadSecretFromManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+// LoadSecretFromManager load from secret manager
+func (ts *TrustStore) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	return nil
 }
 
 // EnsureSecretManager adds  to secret manager
-func (ts *TrustStore) EnsureSecretManager(context context.Context, config *v1alpha1.AppConfig, namespace, secretName string) error {
+func (ts *TrustStore) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
 	return nil
 }
 

--- a/pkg/secretsmanager/secretsmanager.go
+++ b/pkg/secretsmanager/secretsmanager.go
@@ -3,6 +3,10 @@ package secretsmanager
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
 	"strings"
 	"time"
 
@@ -12,141 +16,193 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/prometheus/common/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	awssecretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
+
 	"github.com/pkg/errors"
 	secretspb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ForgeRock/secret-agent/api/v1alpha1"
+	"github.com/ForgeRock/secret-agent/pkg/k8ssecrets"
 )
 
 func idSafe(value string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(value, ".", "-"), "/", "-"), "_", "-")
 }
 
+// SecretManager interface for adding or loading secret manager secrets
 type SecretManager interface {
-	EnsureSecret(ctx context.Context, config *v1alpha1.AppConfig, secretName string, value []byte) error
-	LoadSecret(ctx context.Context, config *v1alpha1.AppConfig, secretName string) ([]byte, error)
+	EnsureSecret(ctx context.Context, secretName string, value []byte) error
+	LoadSecret(ctx context.Context, secretName string) ([]byte, error)
+	CloseClient()
 }
 
-type secretManager struct {
-	gcpClient   *secretmanager.Client
-	awsClient   *awssecretsmanager.SecretsManager
-	azureClient *keyvault.BaseClient
-	config      *v1alpha1.AppConfig
+//  secretManagerGCP container for GCP secret manager properties
+type secretManagerGCP struct {
+	client               *secretmanager.Client
+	secretsManagerPrefix string
+	projectID            string
 }
 
-// func NewSecretManager() SecretManager {
-// 	return &secretManager{}
-// }
-
-// EnsureSecret ensures a secret is stored in secret manager
-func EnsureSecret(ctx context.Context, config *v1alpha1.AppConfig, secretName string, value []byte) error {
-	secretID := idSafe(secretName)
-	if config.SecretsManagerPrefix != "" {
-		secretID = fmt.Sprintf("%s-%s", config.SecretsManagerPrefix, secretID)
-	}
-	switch config.SecretsManager {
-	case v1alpha1.SecretsManagerGCP:
-		err := ensureGCPSecretByID(ctx, config.GCPProjectID, secretID, value)
-		if err != nil {
-			return err
-		}
-	case v1alpha1.SecretsManagerAWS:
-		err := ensureAWSSecretsByID(ctx, config.AWSRegion, secretID, value)
-		if err != nil {
-			return err
-		}
-
-	case v1alpha1.SecretsManagerAzure:
-		client, err := newAzureClient()
-		if err != nil {
-			return err
-		}
-		err = ensureAzureSecretByID(ctx, client, config.AzureVaultName, secretID, value)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+// secretManagerAWS container for AWS secret manager properties
+type secretManagerAWS struct {
+	client               *awssecretsmanager.SecretsManager
+	region               string
+	secretsManagerPrefix string
+	cancel               context.CancelFunc
 }
 
-// LoadSecret Loads secrets from the configured secret manager
-func LoadSecret(ctx context.Context, config *v1alpha1.AppConfig, secretName string) ([]byte, error) {
-	secretID := idSafe(secretName)
-	if config.SecretsManagerPrefix != "" {
-		secretID = fmt.Sprintf("%s-%s", config.SecretsManagerPrefix, secretID)
+// secretManagerAzure container for Azure secret manager properties
+type secretManagerAzure struct {
+	client               *keyvault.BaseClient
+	secretsManagerPrefix string
+	azureVaultName       string
+	cancel               context.CancelFunc
+}
+
+// secretManagerNone container for handling no secret manager
+type secretManagerNone struct {
+}
+
+// NewSecretManager creates a new SecretManager object
+func NewSecretManager(ctx context.Context, instance *v1alpha1.SecretAgentConfiguration, cloudCredNS string, rClient client.Client) (context.Context, SecretManager, error) {
+
+	config := &instance.Spec.AppConfig
+	if len(cloudCredNS) == 0 {
+		cloudCredNS = instance.Namespace
 	}
-	var value []byte
+
+	if instance.Spec.AppConfig.CredentialsSecretName != "" {
+		// load credentials secret
+		secObject, err := k8ssecrets.LoadSecret(rClient,
+			config.CredentialsSecretName, cloudCredNS)
+		if err != nil {
+			log.Error(err, "error loading cloud credentials secret from the Kubernetes API",
+				"secret_name", config.CredentialsSecretName,
+				"cloud_secret_namespace", cloudCredNS)
+			return ctx, nil, err
+		}
+
+		var dir string
+
+		if err := manageCloudCredentials(config.SecretsManager, secObject, dir); err != nil {
+			log.Error(err, "error loading cloud credentials from secret provided",
+				"secret_name", config.CredentialsSecretName,
+				"cloud_secret_namespace", cloudCredNS)
+		}
+	}
+
+	var sm SecretManager
 	var err error
+
+	// decide which SecretManager type based on AppConfig
 	switch config.SecretsManager {
 	case v1alpha1.SecretsManagerGCP:
-		value, err = loadGCPSecretByID(ctx, config.GCPProjectID, secretID)
+		sm, err = newGCP(ctx, config)
 		if err != nil {
-			return []byte{}, err
+			log.Error(err, "couldn't create a new GCP object")
+			return ctx, nil, err
 		}
+		dir, err := ioutil.TempDir("", "cloud_credentials-*")
+		println(dir)
+		if err != nil {
+			log.Error(err, "couldn't create a temporary credentials dir")
+			return ctx, nil, err
+		}
+		// clean up after ourselves
+		defer os.RemoveAll(dir)
 	case v1alpha1.SecretsManagerAWS:
-		value, err = loadAWSSecretByID(config.AWSRegion, secretID)
-		if err != nil {
-			return []byte{}, err
-		}
-
+		ctx, sm = newAWS(ctx, config)
 	case v1alpha1.SecretsManagerAzure:
-		client, err := newAzureClient()
-		secretCtx, cancel := context.WithTimeout(ctx, 40*time.Second)
-		defer cancel()
-		if err != nil {
-			return []byte{}, err
-		}
-		value, err = loadAzureSecretByID(secretCtx, client, config.AzureVaultName, secretID)
-		if err != nil {
-			return []byte{}, err
-		}
-
+		ctx, sm, err = newAzure(ctx, config)
+	case v1alpha1.SecretsManagerNone:
+		sm = newNone() // if secretmanager in the config is "none" then return this
 	}
-	return value, err
 
+	return ctx, sm, err
+}
+
+// newGCP configures a GCP secret manager object
+func newGCP(ctx context.Context, conf *v1alpha1.AppConfig) (*secretManagerGCP, error) {
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		log.Error(err, "couldn't create Google Secret Manager client")
+		return &secretManagerGCP{}, err
+	}
+
+	return &secretManagerGCP{
+		client:               client,
+		secretsManagerPrefix: conf.SecretsManagerPrefix,
+		projectID:            conf.GCPProjectID,
+	}, err
+}
+
+// newAWS configures a AWS secret manager object
+func newAWS(ctx context.Context, conf *v1alpha1.AppConfig) (context.Context, *secretManagerAWS) {
+	client := awssecretsmanager.New(session.New(&aws.Config{Region: aws.String(conf.AWSRegion)}))
+	secretCtx, cancel := context.WithTimeout(ctx, 40*time.Second)
+
+	return secretCtx, &secretManagerAWS{
+		client: client,
+		region: conf.AWSRegion,
+		cancel: cancel,
+	}
+}
+
+// newAzure configures a Azure secret manager object
+func newAzure(ctx context.Context, conf *v1alpha1.AppConfig) (context.Context, *secretManagerAzure, error) {
+	client, err := newAzureClient()
+	secretCtx, cancel := context.WithTimeout(ctx, 40*time.Second)
+
+	return secretCtx, &secretManagerAzure{
+		client:               client,
+		secretsManagerPrefix: conf.SecretsManagerPrefix,
+		azureVaultName:       conf.AzureVaultName,
+		cancel:               cancel,
+	}, err
+}
+
+// newNone configures an empty secret manager object
+func newNone() *secretManagerNone {
+	return &secretManagerNone{}
+}
+
+// getSecretID returns a secretID
+func getSecretID(prefix string, secretName string) string {
+	secretID := idSafe(secretName)
+	if prefix != "" {
+		secretID = fmt.Sprintf("%s-%s", prefix, secretID)
+	}
+	return secretID
 }
 
 // GCP FUNCS
 
-// loadGCPSecretByID loads a single secret out of Google SecretManager, if it exists
-func loadGCPSecretByID(ctx context.Context, projectID string, secretID string) ([]byte, error) {
-	client, err := secretmanager.NewClient(ctx)
-	if err != nil {
-		return []byte{}, err
+// CloseClient closes GCP client
+func (sm *secretManagerGCP) CloseClient() {
+	if err := sm.client.Close(); err != nil {
+		log.Error(err, "Problem closing client")
 	}
-	defer client.Close()
-	name := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projectID, secretID)
-	request := &secretspb.AccessSecretVersionRequest{Name: name}
-	secretResponse, err := client.AccessSecretVersion(ctx, request)
-	if err != nil {
-		stat := status.Convert(err)
-		if stat.Code() == codes.NotFound {
-			// doesn't exist
-			return []byte{}, nil
-		}
-		return []byte{}, errors.WithStack(err)
-	}
-	return secretResponse.GetPayload().GetData(), nil
 }
 
-// ensureGCPSecret ensures a single secret is stored in Google Secret Manager
-func ensureGCPSecretByID(ctx context.Context, projectID, secretID string, value []byte) error {
-	client, err := secretmanager.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-	name := fmt.Sprintf("projects/%s/secrets/%s", projectID, secretID)
+// EnsureSecret ensures a single secret is stored in Google Secret Manager
+func (sm *secretManagerGCP) EnsureSecret(ctx context.Context, secretName string, value []byte) error {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
+	name := fmt.Sprintf("projects/%s/secrets/%s", sm.projectID, secretID)
 
 	// check if exists
 	preExists := true
 	getRequest := &secretspb.GetSecretRequest{Name: name}
-	_, err = client.GetSecret(ctx, getRequest)
+	_, err := sm.client.GetSecret(ctx, getRequest)
+
 	if err != nil {
 		stat := status.Convert(err)
 		if stat.Code() != codes.NotFound {
@@ -155,7 +211,7 @@ func ensureGCPSecretByID(ctx context.Context, projectID, secretID string, value 
 		// doesn't exist, create
 		preExists = false
 		createRequest := &secretspb.CreateSecretRequest{
-			Parent:   fmt.Sprintf("projects/%s", projectID),
+			Parent:   fmt.Sprintf("projects/%s", sm.projectID),
 			SecretId: secretID,
 			Secret: &secretspb.Secret{
 				Name: name,
@@ -166,7 +222,7 @@ func ensureGCPSecretByID(ctx context.Context, projectID, secretID string, value 
 				},
 			},
 		}
-		_, err = client.CreateSecret(ctx, createRequest)
+		_, err = sm.client.CreateSecret(ctx, createRequest)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -183,7 +239,7 @@ func ensureGCPSecretByID(ctx context.Context, projectID, secretID string, value 
 		Parent:  name,
 		Payload: &secretspb.SecretPayload{Data: value},
 	}
-	_, err = client.AddSecretVersion(ctx, secretVersionRequest)
+	_, err = sm.client.AddSecretVersion(ctx, secretVersionRequest)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -191,13 +247,87 @@ func ensureGCPSecretByID(ctx context.Context, projectID, secretID string, value 
 	return nil
 }
 
+// LoadSecret loads a single secret out of Google SecretManager, if it exists
+func (sm *secretManagerGCP) LoadSecret(ctx context.Context, secretName string) ([]byte, error) {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
+	name := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", sm.projectID, secretID)
+	request := &secretspb.AccessSecretVersionRequest{Name: name}
+	secretResponse, err := sm.client.AccessSecretVersion(ctx, request)
+
+	if err != nil {
+		stat := status.Convert(err)
+		if stat.Code() == codes.NotFound {
+			// doesn't exist
+			return []byte{}, nil
+		}
+		return []byte{}, errors.WithStack(err)
+	}
+	return secretResponse.GetPayload().GetData(), nil
+}
+
 // AWS FUNCS
 
-// loadAWSSecretByID loads a single secret out of AWS SecretsManager, if it exists
-func loadAWSSecretByID(awsRegion string, secretID string) ([]byte, error) {
-	service := awssecretsmanager.New(session.New(&aws.Config{Region: aws.String(awsRegion)}))
+// CloseClient closes AWS client
+func (sm *secretManagerAWS) CloseClient() {
+	sm.cancel()
+}
+
+// EnsureSecret saves secret to AWS secret manager
+func (sm *secretManagerAWS) EnsureSecret(ctx context.Context, secretName string, value []byte) error {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
+	// check if exists
+	preExists := true
 	request := &awssecretsmanager.GetSecretValueInput{SecretId: aws.String(secretID)}
-	result, err := service.GetSecretValue(request)
+	_, err := sm.client.GetSecretValue(request)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() != awssecretsmanager.ErrCodeResourceNotFoundException {
+				return errors.WithStack(err)
+			}
+			// doesn't exist, create
+			preExists = false
+			input := &awssecretsmanager.CreateSecretInput{
+				Name: aws.String(secretID),
+			}
+			_, err = sm.client.CreateSecret(input)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		} else {
+			return errors.WithStack(err)
+		}
+	}
+
+	// only add new version if secret was created this round, because
+	//   otherwise the in memory version was read from SM and is already correct
+	if preExists {
+		return nil
+	}
+
+	// add secret version
+	input := &awssecretsmanager.PutSecretValueInput{
+		SecretId:     aws.String(secretID),
+		SecretBinary: value,
+	}
+	_, err = sm.client.PutSecretValue(input)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// LoadSecret loads a single secret out of AWS SecretsManager, if it exists
+func (sm *secretManagerAWS) LoadSecret(ctx context.Context, secretName string) ([]byte, error) {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
+	request := &awssecretsmanager.GetSecretValueInput{SecretId: aws.String(secretID)}
+	result, err := sm.client.GetSecretValue(request)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == awssecretsmanager.ErrCodeResourceNotFoundException {
@@ -211,52 +341,12 @@ func loadAWSSecretByID(awsRegion string, secretID string) ([]byte, error) {
 	return result.SecretBinary, nil
 }
 
-// ensureAWSSecretsByID ensures a single secret is stored in AWS Secret Manager
-func ensureAWSSecretsByID(ctx context.Context, awsRegion, secretID string, value []byte) error {
-	service := awssecretsmanager.New(session.New(&aws.Config{Region: aws.String(awsRegion)}))
-
-	// check if exists
-	preExists := true
-	request := &awssecretsmanager.GetSecretValueInput{SecretId: aws.String(secretID)}
-	_, err := service.GetSecretValue(request)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() != awssecretsmanager.ErrCodeResourceNotFoundException {
-				return errors.WithStack(err)
-			}
-			// doesn't exist, create
-			preExists = false
-			input := &awssecretsmanager.CreateSecretInput{
-				Name: aws.String(secretID),
-			}
-			_, err = service.CreateSecret(input)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-		} else {
-			return errors.WithStack(err)
-		}
-	}
-	// only add new version if secret was created this round, because
-	//   otherwise the in memory version was read from SM and is already correct
-	if preExists {
-		return nil
-	}
-
-	// add secret version
-	input := &awssecretsmanager.PutSecretValueInput{
-		SecretId:     aws.String(secretID),
-		SecretBinary: value,
-	}
-	_, err = service.PutSecretValue(input)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	return nil
-}
-
 // AZURE FUNCS
+
+// CloseClient closes Azure client
+func (sm *secretManagerAzure) CloseClient() {
+	sm.cancel()
+}
 
 var azureVaultURLFmt string = "https://%s.vault.azure.net/"
 
@@ -272,22 +362,27 @@ func newAzureClient() (*keyvault.BaseClient, error) {
 	return &client, nil
 }
 
-// ensureAzureSecretByID write bytes to azure keyvault
-func ensureAzureSecretByID(ctx context.Context, client *keyvault.BaseClient, vaultName, secretID string, value []byte) error {
+// EnsureSecret ensures a single secret is stored in AWS Secret Manager
+func (sm *secretManagerAzure) EnsureSecret(ctx context.Context, secretName string, value []byte) error {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
 	var secParams keyvault.SecretSetParameters
 	stringValue := string(value)
 	secParams.Value = &stringValue
-	_, err := client.SetSecret(ctx, fmt.Sprintf(azureVaultURLFmt, vaultName), secretID, secParams)
+	_, err := sm.client.SetSecret(ctx, fmt.Sprintf(azureVaultURLFmt, sm.azureVaultName), secretID, secParams)
 	if err != nil {
 		return errors.WithStack(fmt.Errorf("unable to write %s to azure vault", secretID))
 	}
 	return nil
-
 }
 
-// loadAzureSecretByID load a secret from Azure Key Vault
-func loadAzureSecretByID(ctx context.Context, client *keyvault.BaseClient, vaultName, secretID string) ([]byte, error) {
-	response, err := client.GetSecret(ctx, fmt.Sprintf(azureVaultURLFmt, vaultName), secretID, "")
+// LoadSecret loads a secret from Azure Key Vault
+func (sm *secretManagerAzure) LoadSecret(ctx context.Context, secretName string) ([]byte, error) {
+	// get secret ID
+	secretID := getSecretID(sm.secretsManagerPrefix, secretName)
+
+	response, err := sm.client.GetSecret(ctx, fmt.Sprintf(azureVaultURLFmt, sm.azureVaultName), secretID, "")
 	if err != nil {
 		if e, ok := err.(autorest.DetailedError); ok && e.StatusCode.(int) == 404 {
 			return []byte{}, nil
@@ -299,4 +394,90 @@ func loadAzureSecretByID(ctx context.Context, client *keyvault.BaseClient, vault
 		return []byte{}, errors.WithStack(fmt.Errorf("no secret found for %s", secretID))
 	}
 	return []byte(*response.Value), nil
+}
+
+// No Secret Manager Client
+func (sm *secretManagerNone) CloseClient() {}
+
+// EnsureSecret returns nil if SecretsManagerNone is true
+func (sm *secretManagerNone) EnsureSecret(ctx context.Context, secretName string, value []byte) error {
+	return nil
+}
+
+// LoadSecret returns nil if SecretsManagerNone is true
+func (sm *secretManagerNone) LoadSecret(ctx context.Context, secretName string) ([]byte, error) {
+	return nil, nil
+}
+
+// manageCloudCredentials handles the credential used to access the secret manager
+// credentials are placed in temp files or environmental variables according to the SM specs.
+func manageCloudCredentials(secMan v1alpha1.SecretsManager, secObject *corev1.Secret, dirPath string) error {
+
+	writeFile := func(name string, contents []byte) (string, error) {
+		fPath := path.Join(dirPath, name)
+
+		// Open a new file for writing only
+		file, err := os.OpenFile(
+			fPath,
+			os.O_WRONLY|os.O_TRUNC|os.O_CREATE,
+			0666,
+		)
+		if err != nil {
+			return "", err
+		}
+		defer file.Close()
+
+		// Write bytes to file
+		_, err = file.Write(contents)
+		if err != nil {
+			return "", err
+		}
+		return fPath, nil
+	}
+	switch secMan {
+	case v1alpha1.SecretsManagerGCP:
+		keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerGoogleApplicationCredentials)]
+		if !ok {
+			return fmt.Errorf(fmt.Sprintf("%s must be provided in a credentials secret",
+				v1alpha1.SecretsManagerGoogleApplicationCredentials))
+		}
+		fp, err := writeFile("gcp_credentials.json", keyValue)
+		if err != nil {
+			return err
+		}
+		if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fp); err != nil {
+			return err
+		}
+	case v1alpha1.SecretsManagerAWS:
+		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAwsAccessKeyID)]; ok {
+			if err := os.Setenv("AWS_ACCESS_KEY_ID", string(keyValue)); err != nil {
+				return err
+			}
+		}
+		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAwsSecretAccessKey)]; ok {
+			if err := os.Setenv("AWS_SECRET_ACCESS_KEY", string(keyValue)); err != nil {
+				return err
+			}
+		}
+	case v1alpha1.SecretsManagerAzure:
+		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAzureTenantID)]; ok {
+			if err := os.Setenv("AZURE_TENANT_ID", string(keyValue)); err != nil {
+				return err
+			}
+
+		}
+		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAzureClientID)]; ok {
+			if err := os.Setenv("AZURE_CLIENT_ID", string(keyValue)); err != nil {
+				return err
+			}
+
+		}
+		if keyValue, ok := secObject.Data[string(v1alpha1.SecretsManagerAzureClientSecret)]; ok {
+			if err := os.Setenv("AZURE_CLIENT_SECRET", string(keyValue)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+
 }


### PR DESCRIPTION
Create newSecretManager function to create a new cloud vendor specific SecretManager object.
Create new SecretManager interface to execute loading and adding of secrets and closing of clients.
Move all secret manager logic to the secretsmanager package.
Update generator packages to call the SecretManager interface.

Closes #166