### PR TITLE
Reconcile deletes unwanted secrets + fix status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 IMG ?= controller:latest
 VERSION=$(shell echo $(IMG) | awk -F ':' '{print $$2}')
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+#CRD_OPTIONS ?= "crd:trivialVersions=false"
+# This will work on kube versions 1.16+. We want the CRD OpenAPI validation features in v1
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -192,12 +192,15 @@ type AppConfig struct {
 	AzureVaultName        string         `json:"azureVaultName,omitempty"`
 
 	// Optional timeout value to generate a individual secret. Defaults to 40
+	// +kubebuilder:default:=40
 	SecretTimeout *int `json:"secretTimeout,omitempty"`
 
 	// Optional number of times the operator will attempt to generate secrets. Defaults to 3
+	// +kubebuilder:default:=3
 	MaxRetries *int `json:"maxRetries,omitempty"`
 
 	// Optional backoff time in seconds before retrying secret generation. Defaults to 2
+	// +kubebuilder:default:=2
 	BackOffSecs *int `json:"backOffSecs,omitempty"`
 }
 

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,20 +8,6 @@ metadata:
   creationTimestamp: null
   name: secretagentconfigurations.secret-agent.secrets.forgerock.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    description: SAC State
-    name: Status
-    type: string
-  - JSONPath: .status.totalManagedObjects
-    description: Total no. of objects managed
-    name: TotalNumObjects
-    type: integer
-  - JSONPath: .status.managedK8sSecrets
-    description: All K8s managed secrets
-    name: K8sSecrets
-    priority: 1
-    type: string
   group: secret-agent.secrets.forgerock.io
   names:
     kind: SecretAgentConfiguration
@@ -31,256 +17,275 @@ spec:
     - sac
     singular: secretagentconfiguration
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SecretAgentConfiguration is the Schema for the secretagentconfigurations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SecretAgentConfigurationSpec defines the desired state of SecretAgentConfiguration
-          properties:
-            appConfig:
-              description: AppConfig is the configuration for the forgeops-secrets
-                application
-              properties:
-                awsRegion:
-                  type: string
-                azureVaultName:
-                  type: string
-                backOffSecs:
-                  description: Optional backoff time in seconds before retrying secret
-                    generation. Defaults to 2
-                  type: integer
-                createKubernetesObjects:
-                  type: boolean
-                credentialsSecretName:
-                  type: string
-                gcpProjectID:
-                  type: string
-                maxRetries:
-                  description: Optional number of times the operator will attempt
-                    to generate secrets. Defaults to 3
-                  type: integer
-                secretTimeout:
-                  description: Optional timeout value to generate a individual secret.
-                    Defaults to 40
-                  type: integer
-                secretsManager:
-                  description: SecretsManager Specifies which cloud secret manager
-                    will be used
-                  enum:
-                  - none
-                  - GCP
-                  - AWS
-                  - Azure
-                  type: string
-                secretsManagerPrefix:
-                  type: string
-              required:
-              - createKubernetesObjects
-              - secretsManager
-              type: object
-            secrets:
-              items:
-                description: SecretConfig is the configuration for a specific Kubernetes
-                  secret
+  versions:
+  - additionalPrinterColumns:
+    - description: SAC State
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: Total no. of objects managed
+      jsonPath: .status.totalManagedObjects
+      name: TotalNumObjects
+      type: integer
+    - description: All K8s managed secrets
+      jsonPath: .status.managedK8sSecrets
+      name: K8sSecrets
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecretAgentConfiguration is the Schema for the secretagentconfigurations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecretAgentConfigurationSpec defines the desired state of
+              SecretAgentConfiguration
+            properties:
+              appConfig:
+                description: AppConfig is the configuration for the forgeops-secrets
+                  application
                 properties:
-                  keys:
-                    items:
-                      description: KeyConfig is the configuration for a specific data
-                        key
-                      properties:
-                        name:
-                          type: string
-                        spec:
-                          description: KeySpec is the configuration for each key
-                          properties:
-                            algorithm:
-                              description: AlgorithmType Specifies which keystore
-                                algorithm to use
-                              enum:
-                              - ECDSAWithSHA256
-                              - SHA256WithRSA
-                              type: string
-                            distinguishedName:
-                              description: DistinguishedName certificate subject data
-                              properties:
-                                commonName:
-                                  type: string
-                                country:
-                                  items:
-                                    type: string
-                                  type: array
-                                locality:
-                                  items:
-                                    type: string
-                                  type: array
-                                organization:
-                                  items:
-                                    type: string
-                                  type: array
-                                organizationUnit:
-                                  items:
-                                    type: string
-                                  type: array
-                                postalCode:
-                                  items:
-                                    type: string
-                                  type: array
-                                province:
-                                  items:
-                                    type: string
-                                  type: array
-                                serialNumber:
-                                  type: string
-                                streetAddress:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            duration:
-                              type: string
-                            isBase64:
-                              type: boolean
-                            keyPassPath:
-                              type: string
-                            keytoolAliases:
-                              items:
-                                description: KeytoolAliasConfig is the configuration
-                                  for a keystore alias
+                  awsRegion:
+                    type: string
+                  azureVaultName:
+                    type: string
+                  backOffSecs:
+                    default: 2
+                    description: Optional backoff time in seconds before retrying
+                      secret generation. Defaults to 2
+                    type: integer
+                  createKubernetesObjects:
+                    type: boolean
+                  credentialsSecretName:
+                    type: string
+                  gcpProjectID:
+                    type: string
+                  maxRetries:
+                    default: 3
+                    description: Optional number of times the operator will attempt
+                      to generate secrets. Defaults to 3
+                    type: integer
+                  secretTimeout:
+                    default: 40
+                    description: Optional timeout value to generate a individual secret.
+                      Defaults to 40
+                    type: integer
+                  secretsManager:
+                    description: SecretsManager Specifies which cloud secret manager
+                      will be used
+                    enum:
+                    - none
+                    - GCP
+                    - AWS
+                    - Azure
+                    type: string
+                  secretsManagerPrefix:
+                    type: string
+                required:
+                - createKubernetesObjects
+                - secretsManager
+                type: object
+              secrets:
+                items:
+                  description: SecretConfig is the configuration for a specific Kubernetes
+                    secret
+                  properties:
+                    keys:
+                      items:
+                        description: KeyConfig is the configuration for a specific
+                          data key
+                        properties:
+                          name:
+                            type: string
+                          spec:
+                            description: KeySpec is the configuration for each key
+                            properties:
+                              algorithm:
+                                description: AlgorithmType Specifies which keystore
+                                  algorithm to use
+                                enum:
+                                - ECDSAWithSHA256
+                                - SHA256WithRSA
+                                type: string
+                              distinguishedName:
+                                description: DistinguishedName certificate subject
+                                  data
                                 properties:
-                                  args:
+                                  commonName:
+                                    type: string
+                                  country:
                                     items:
                                       type: string
                                     type: array
-                                  cmd:
-                                    description: KeytoolCmd Specifies the keytool
-                                      command to use.
-                                    enum:
-                                    - genkeypair
-                                    - genseckey
-                                    - importcert
-                                    - importpassword
-                                    - importkeystore
+                                  locality:
+                                    items:
+                                      type: string
+                                    type: array
+                                  organization:
+                                    items:
+                                      type: string
+                                    type: array
+                                  organizationUnit:
+                                    items:
+                                      type: string
+                                    type: array
+                                  postalCode:
+                                    items:
+                                      type: string
+                                    type: array
+                                  province:
+                                    items:
+                                      type: string
+                                    type: array
+                                  serialNumber:
                                     type: string
-                                  isKeyPair:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  sourcePath:
-                                    type: string
-                                required:
-                                - cmd
-                                - name
+                                  streetAddress:
+                                    items:
+                                      type: string
+                                    type: array
                                 type: object
-                              minItems: 1
-                              type: array
-                            length:
-                              type: integer
-                            sans:
-                              items:
+                              duration:
                                 type: string
-                              type: array
-                            selfSigned:
-                              type: boolean
-                            signedWithPath:
-                              type: string
-                            storePassPath:
-                              type: string
-                            storeType:
-                              description: StoreType Specifies which keystore store
-                                type to use
-                              enum:
-                              - pkcs12
-                              - jceks
-                              - jks
-                              type: string
-                            truststoreImportPaths:
-                              items:
+                              isBase64:
+                                type: boolean
+                              keyPassPath:
                                 type: string
-                              type: array
-                            useBinaryCharacters:
-                              type: boolean
-                            value:
-                              type: string
-                          type: object
-                        type:
-                          description: KeyConfigType Specifies which key type to use
-                          enum:
-                          - ca
-                          - literal
-                          - password
-                          - ssh
-                          - keyPair
-                          - truststore
-                          - keytool
-                          type: string
-                      required:
-                      - name
-                      - type
-                      type: object
-                    minItems: 1
-                    type: array
-                  name:
-                    type: string
-                required:
-                - keys
-                - name
-                type: object
-              minItems: 1
-              type: array
-          required:
-          - appConfig
-          - secrets
-          type: object
-        status:
-          description: SecretAgentConfigurationStatus defines the observed state of
-            SecretAgentConfiguration
-          properties:
-            managedAWSSecrets:
-              items:
+                              keytoolAliases:
+                                items:
+                                  description: KeytoolAliasConfig is the configuration
+                                    for a keystore alias
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    cmd:
+                                      description: KeytoolCmd Specifies the keytool
+                                        command to use.
+                                      enum:
+                                      - genkeypair
+                                      - genseckey
+                                      - importcert
+                                      - importpassword
+                                      - importkeystore
+                                      type: string
+                                    isKeyPair:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    sourcePath:
+                                      type: string
+                                  required:
+                                  - cmd
+                                  - name
+                                  type: object
+                                minItems: 1
+                                type: array
+                              length:
+                                type: integer
+                              sans:
+                                items:
+                                  type: string
+                                type: array
+                              selfSigned:
+                                type: boolean
+                              signedWithPath:
+                                type: string
+                              storePassPath:
+                                type: string
+                              storeType:
+                                description: StoreType Specifies which keystore store
+                                  type to use
+                                enum:
+                                - pkcs12
+                                - jceks
+                                - jks
+                                type: string
+                              truststoreImportPaths:
+                                items:
+                                  type: string
+                                type: array
+                              useBinaryCharacters:
+                                type: boolean
+                              value:
+                                type: string
+                            type: object
+                          type:
+                            description: KeyConfigType Specifies which key type to
+                              use
+                            enum:
+                            - ca
+                            - literal
+                            - password
+                            - ssh
+                            - keyPair
+                            - truststore
+                            - keytool
+                            type: string
+                        required:
+                        - name
+                        - type
+                        type: object
+                      minItems: 1
+                      type: array
+                    name:
+                      type: string
+                  required:
+                  - keys
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - appConfig
+            - secrets
+            type: object
+          status:
+            description: SecretAgentConfigurationStatus defines the observed state
+              of SecretAgentConfiguration
+            properties:
+              managedAWSSecrets:
+                items:
+                  type: string
+                type: array
+              managedAzureSecrets:
+                items:
+                  type: string
+                type: array
+              managedGCPSecrets:
+                items:
+                  type: string
+                type: array
+              managedK8sSecrets:
+                items:
+                  type: string
+                type: array
+              state:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
                 type: string
-              type: array
-            managedAzureSecrets:
-              items:
-                type: string
-              type: array
-            managedGCPSecrets:
-              items:
-                type: string
-              type: array
-            managedK8sSecrets:
-              items:
-                type: string
-              type: array
-            state:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              type: string
-            totalManagedObjects:
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              totalManagedObjects:
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/k8ssecrets/k8ssecrets.go
+++ b/pkg/k8ssecrets/k8ssecrets.go
@@ -65,3 +65,13 @@ func ApplySecrets(rclient client.Client, secret *corev1.Secret) (string, error) 
 
 	return operation, nil
 }
+
+// DeleteSecret deletes the secret from the Kubernetes API
+func DeleteSecret(rclient client.Client, secretName, namespace string) (*corev1.Secret, error) {
+	k8sSecret, err := LoadSecret(rclient, secretName, namespace)
+	if err != nil {
+		return k8sSecret, err
+	}
+	err = rclient.Delete(context.TODO(), k8sSecret, client.PropagationPolicy("Background"))
+	return k8sSecret, nil
+}


### PR DESCRIPTION
1. Reconcile deletes secrets when they are removed from the SAC
1. Fix SAC status
1. Upgrade CRD definition to `apiextensions.k8s.io/v1` (req k8s 1.16+)
1. Set default secret timeout using openAPI

Closes #162
Closes #171