### PR TITLE
feat: Add "combined" output for PEM keypairs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ debug: generate fmt vet manifests
 	dlv debug -- ./main.$(GO) --debug
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	$(GO) run ./main.go
+	ENABLE_WEBHOOKS=false $(GO) run ./main.go
 
 # Install CRDs into a cluster
 install: manifests

--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -191,8 +191,10 @@ func (kp *CertKeyPair) InSecret(secObject *corev1.Secret) bool {
 
 	publicPemKey := fmt.Sprintf("%s.pem", kp.Name)
 	privatePemKey := fmt.Sprintf("%s-private.pem", kp.Name)
+	combinedPemKey := fmt.Sprintf("%s-combined.pem", kp.Name)
 	if secObject.Data == nil || secObject.Data[publicPemKey] == nil ||
-		secObject.Data[privatePemKey] == nil || kp.IsEmpty() {
+		secObject.Data[privatePemKey] == nil || secObject.Data[combinedPemKey] == nil ||
+		kp.IsEmpty() {
 		return false
 	}
 	if bytes.Compare(secObject.Data[publicPemKey], kp.Cert.CertPEM) == 0 &&
@@ -359,8 +361,10 @@ func (kp *CertKeyPair) ToKubernetes(secObject *corev1.Secret) {
 	}
 	publicPemKey := fmt.Sprintf("%s.pem", kp.Name)
 	privatePemKey := fmt.Sprintf("%s-private.pem", kp.Name)
+	combinedPemKey := fmt.Sprintf("%s-combined.pem", kp.Name)
 	secObject.Data[publicPemKey] = kp.Cert.CertPEM
 	secObject.Data[privatePemKey] = kp.Cert.PrivateKeyPEM
+	secObject.Data[combinedPemKey] = append(kp.Cert.CertPEM, kp.Cert.PrivateKeyPEM...)
 	return
 }
 


### PR DESCRIPTION
1. Add "combined" output for PEM keypairs
1. "Combined" output contains private + public keys in a single PEM file
1. Add `ENABLE_WEBHOOKS=false` to `make run` target to allow the operator to run locally.