### PR TITLE
feat: setting secretsManagerPrefix on a sac will no longer use a name…

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,11 @@ All that is required is to provide a Kubernetes secret with the same name and sa
 There is a naming convention used by `secret-agent` to store and read secrets from the cloud secret managers. In general, the names follow the format:
 
 ```bash
-$prefix-$namespace-$secretName-$keyName [If secretsManagerPrefix is provided]
+$prefix-$secretName-$keyName [If secretsManagerPrefix is provided]
 $namespace-$secretName-$keyName [If no prefix is provided]
 ```
+
+When using a SecretsManagerPrefix writes to a secret manager doesn't use namespace, make sure your prefixes are unique.
 
 Due to cloud provider limitations, all `/`, `.` and `_` characters in secret names are replaced by `-` when accessing the cloud secret managers.
 
@@ -277,7 +279,7 @@ Parameter | Description | Default
 `spec.appConfig.createKubernetesObjects` | Create Kubernetes secrets for each generated secret. Can't be set to false if `spec.appConfig.secretsManager` is set to "none" | true
 `spec.appConfig.secretTimeout` | Set the timeout in seconds for generating each individual secret | 40
 `spec.appConfig.secretsManager` | Select the cloud provider to target. If "none", secrets will not be backed up in any cloud secret manager. Can't be set to "none" if `spec.appConfig.createKubernetesObjects` is false| none
-`spec.appConfig.secretsManagerPrefix` | Prefix added to the name of the secrets stored in the cloud secret manager. | ""
+`spec.appConfig.secretsManagerPrefix` | Prefix added to the name of the secrets stored in the cloud secret manager instead of the namespace. | ""
 `spec.appConfig.credentialsSecretName` | Name of the Kubernetes secret containing the credentials to access the cloud provider. | ""
 `spec.appConfig.gcpProjectID` | When using GCP as the secret mgr, specify the project ID.  | ""
 `spec.appConfig.awsRegion` | When using AWS  as the secret mgr, specify the region.  | ""

--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -9,11 +9,12 @@ spec:
   appConfig:
     createKubernetesObjects: true
     ## Timeout in seconds for generating each individual secret. Default 40
-    # secretTimeout: 40 
+    # secretTimeout: 40
 
     # A cloud provider's secret manager is the source of truth.
     # If secrets don't exist, they are generated and stored in the manager.
     secretsManager: none # none, AWS, Azure, or GCP
+    ## prefix added to the name of the secrets stored in the cloud secret manager instead of the namespace.
     # secretsManagerPrefix: "prefix"
     ## credentials for cloud provider (optional. see README.md)
     # credentialsSecretName: cloud-credentials
@@ -121,7 +122,7 @@ spec:
       - name: ds.pem
         type: truststore
         spec:
-          # Write public keys in PEM format instead of pkcs12 
+          # Write public keys in PEM format instead of pkcs12
           pemFormat: true
           truststoreImportPaths: ["platform-ca/ca"]
 

--- a/pkg/generator/certificate.go
+++ b/pkg/generator/certificate.go
@@ -153,10 +153,10 @@ func (kp *CertKeyPair) References() ([]string, []string) {
 }
 
 // LoadSecretFromManager populates RootCA data from secret manager
-func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	publicPemKeyFmt := fmt.Sprintf("%s_%s_%s.pem", namespace, secretName, kp.Name)
-	privatePemKeyFmt := fmt.Sprintf("%s_%s_%s-private.pem", namespace, secretName, kp.Name)
+	publicPemKeyFmt := fmt.Sprintf("%s_%s.pem", secretManagerKeyNamespace, kp.Name)
+	privatePemKeyFmt := fmt.Sprintf("%s_%s-private.pem", secretManagerKeyNamespace, kp.Name)
 
 	kp.Cert.CertPEM, err = sm.LoadSecret(ctx, publicPemKeyFmt)
 	if err != nil {
@@ -170,10 +170,10 @@ func (kp *CertKeyPair) LoadSecretFromManager(ctx context.Context, sm secretsmana
 }
 
 // EnsureSecretManager populates secrete manager from RootCA data
-func (kp *CertKeyPair) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (kp *CertKeyPair) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	publicPemKeyFmt := fmt.Sprintf("%s_%s_%s.pem", namespace, secretName, kp.Name)
-	privatePemKeyFmt := fmt.Sprintf("%s_%s_%s-private.pem", namespace, secretName, kp.Name)
+	publicPemKeyFmt := fmt.Sprintf("%s_%s.pem", secretManagerKeyNamespace, kp.Name)
+	privatePemKeyFmt := fmt.Sprintf("%s_%s-private.pem", secretManagerKeyNamespace, kp.Name)
 	err = sm.EnsureSecret(ctx, publicPemKeyFmt, kp.Cert.CertPEM)
 	if err != nil {
 		return err

--- a/pkg/generator/keytool.go
+++ b/pkg/generator/keytool.go
@@ -172,11 +172,11 @@ func (kt *KeyTool) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager  populates keytool data from secret manager
-func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	keyToolFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, kt.Name)
-	storePassFmt := fmt.Sprintf("%s_%s_%s_storepass", namespace, secretName, kt.Name)
-	keyPasslFmt := fmt.Sprintf("%s_%s_%s_keypass", namespace, secretName, kt.Name)
+	keyToolFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, kt.Name)
+	storePassFmt := fmt.Sprintf("%s_%s_storepass", secretManagerKeyNamespace, kt.Name)
+	keyPasslFmt := fmt.Sprintf("%s_%s_keypass", secretManagerKeyNamespace, kt.Name)
 	kt.storeBytes, err = sm.LoadSecret(ctx, keyToolFmt)
 	if err != nil {
 		return err
@@ -195,12 +195,12 @@ func (kt *KeyTool) LoadSecretFromManager(ctx context.Context, sm secretsmanager.
 }
 
 // EnsureSecretManager adds keytool to secret manager
-func (kt *KeyTool) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (kt *KeyTool) EnsureSecretManager(ctx context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 
 	var err error
-	keyToolFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, kt.Name)
-	storePassFmt := fmt.Sprintf("%s_%s_%s_storepass", namespace, secretName, kt.Name)
-	keyPasslFmt := fmt.Sprintf("%s_%s_%s_keypass", namespace, secretName, kt.Name)
+	keyToolFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, kt.Name)
+	storePassFmt := fmt.Sprintf("%s_%s_storepass", secretManagerKeyNamespace, kt.Name)
+	keyPasslFmt := fmt.Sprintf("%s_%s_keypass", secretManagerKeyNamespace, kt.Name)
 
 	err = sm.EnsureSecret(ctx, keyToolFmt, kt.storeBytes)
 	if err != nil {

--- a/pkg/generator/literal.go
+++ b/pkg/generator/literal.go
@@ -32,9 +32,9 @@ func (literal *Literal) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates Literal data from secret manager
-func (literal *Literal) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (literal *Literal) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
+	literalFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, literal.Name)
 	literal.Value, err = sm.LoadSecret(context, literalFmt)
 	if err != nil {
 		return err
@@ -43,9 +43,9 @@ func (literal *Literal) LoadSecretFromManager(context context.Context, sm secret
 }
 
 // EnsureSecretManager populates secrets manager from Literal data
-func (literal *Literal) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (literal *Literal) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	literalFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, literal.Name)
+	literalFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, literal.Name)
 	err = sm.EnsureSecret(context, literalFmt, literal.Value)
 	if err != nil {
 		return err

--- a/pkg/generator/password.go
+++ b/pkg/generator/password.go
@@ -35,9 +35,9 @@ func (pwd *Password) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates Password data from secret manager
-func (pwd *Password) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (pwd *Password) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	pwdFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, pwd.Name)
+	pwdFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, pwd.Name)
 	pwd.Value, err = sm.LoadSecret(context, pwdFmt)
 	if err != nil {
 		return err
@@ -46,9 +46,9 @@ func (pwd *Password) LoadSecretFromManager(context context.Context, sm secretsma
 }
 
 // EnsureSecretManager populates secrets manager from Password data
-func (pwd *Password) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (pwd *Password) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	pwdFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, pwd.Name)
+	pwdFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, pwd.Name)
 	err = sm.EnsureSecret(context, pwdFmt, pwd.Value)
 	if err != nil {
 		return err

--- a/pkg/generator/ssh.go
+++ b/pkg/generator/ssh.go
@@ -35,10 +35,10 @@ func (ssh *SSH) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager populates SSH data from secret manager
-func (ssh *SSH) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (ssh *SSH) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	var err error
-	sshPrivateFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, ssh.Name)
-	sshPublicFmt := fmt.Sprintf("%s_%s_%s.pub", namespace, secretName, ssh.Name)
+	sshPrivateFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, ssh.Name)
+	sshPublicFmt := fmt.Sprintf("%s_%s.pub", secretManagerKeyNamespace, ssh.Name)
 
 	ssh.PrivateKeyPEM, err = sm.LoadSecret(context, sshPrivateFmt)
 	if err != nil {
@@ -52,9 +52,9 @@ func (ssh *SSH) LoadSecretFromManager(context context.Context, sm secretsmanager
 }
 
 // EnsureSecretManager populates secrets manager from SSH data
-func (ssh *SSH) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
-	sshPrivateFmt := fmt.Sprintf("%s_%s_%s", namespace, secretName, ssh.Name)
-	sshPublicFmt := fmt.Sprintf("%s_%s_%s.pub", namespace, secretName, ssh.Name)
+func (ssh *SSH) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
+	sshPrivateFmt := fmt.Sprintf("%s_%s", secretManagerKeyNamespace, ssh.Name)
+	sshPublicFmt := fmt.Sprintf("%s_%s.pub", secretManagerKeyNamespace, ssh.Name)
 
 	if err := sm.EnsureSecret(context, sshPrivateFmt, ssh.PrivateKeyPEM); err != nil {
 		return err

--- a/pkg/generator/truststore.go
+++ b/pkg/generator/truststore.go
@@ -79,12 +79,12 @@ func (ts *TrustStore) LoadReferenceData(data map[string][]byte) error {
 }
 
 // LoadSecretFromManager load from secret manager
-func (ts *TrustStore) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (ts *TrustStore) LoadSecretFromManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	return nil
 }
 
 // EnsureSecretManager adds  to secret manager
-func (ts *TrustStore) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, namespace, secretName string) error {
+func (ts *TrustStore) EnsureSecretManager(context context.Context, sm secretsmanager.SecretManager, secretManagerKeyNamespace string) error {
 	return nil
 }
 


### PR DESCRIPTION
…space in the key name

ref: cloud-3071

This is desired by PIT teams or anyone who wants to restore secrets from independent of namepsace. 