### PR TITLE
fix: update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,47 +4,8 @@ on:
     tags: [ "*" ]
 
 jobs:
-  basic-checks:
-    name: Run basic-checks
-    runs-on: ubuntu-latest
-    # container: golang:1.14-buster
-    steps:
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: go-fmt
-      run: go fmt ./...
-
-    - name: Check for uncommited files
-      run: if [ -n "$(git status --untracked-files=no --porcelain)" ]; then echo "There are uncommitted changes"; exit 1; fi
-    
-    - name: Run tests
-      run: go test ./... -cover
-    
-  integration-tests:
-    name: Run integration-tests
-    needs: basic-checks
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-       
-    - name: Build Test Image
-      run: docker build -t secret-agent-tester --target=tester .
-
-    - name: Test
-      run: docker run -i --rm -v ${GITHUB_WORKSPACE}:/root/go/src/github.com/ForgeRock/secret-agent secret-agent-tester make citest
-
   build:
     name: Release
-    needs: integration-tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -55,27 +16,25 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: ^1.16
       id: go
 
     - name: Setup Kustomize
       uses: imranismail/setup-kustomize@v1
       with:
         kustomize-version: "3.9.3"
-
     - name: Set Go Releaser Environment
       run: |
         echo "GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true) >> $GITHUB_ENV
         echo "BUILD_DATE="$(date '+%Y-%m-%d-%H:%M:%S') >> $GITHUB_ENV
         echo "TAG_NAME="$(git describe --tags --abbrev=0) >> $GITHUB_ENV
-  
+
     - name: Kustomize Build
       run: |
         cd config/manager
         kustomize edit set image controller=forgerock/secret-agent:${TAG_NAME}
         cd ../../
         kustomize build config/default > secret-agent.yaml
-        kustomize build config/ha > secret-agent-ha.yaml
         git checkout -- config/manager/kustomization.yaml
 
     - name: Create Release
@@ -85,15 +44,15 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_COMMIT: ${{ github.sha }} 
+        GIT_COMMIT: ${{ github.sha }}
         IMAGE_NAME: "forgerock/secret-agent"
-  
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: artifacts
         path: dist/*.tar.gz
-    
+
     - name: Register pkg with pkg.go.dev
       run: |
         curl https://proxy.golang.org/github.com/forgerock/secret-agent/@v/${TAG_NAME}.info

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,12 @@ bin
 *.swp
 *.swo
 *~
+
+/.project
+/.vscode/
+
+testConfiguration1.yaml
+testConfiguration2.yaml
+secret-agent.yaml
+secret-agent-ha.yaml
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,4 +32,3 @@ release:
   name_template: "{{.Tag}}"
   extra_files:
     - glob: ./secret-agent.yaml
-    - glob: ./secret-agent-ha.yaml


### PR DESCRIPTION
Updated to use Go 1.16, dropped steps that are already required to be run in PR