### PR TITLE
fix: Flags parsed after logger opts initialized, leading to debug to …

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,11 +65,11 @@ func main() {
 	flag.StringVar(&cloudSecretsNamespace, "cloud-secrets-namespace", "",
 		"Namespace where the cloud credentials secrets are located. Defaults to the SAC namespace")
 
+	flag.Parse()
 	opts := zap.Options{
 		Development: debug,
 	}
 	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
…always be set to false

Left over upgrade bug kb3 upgrade. Parse flags before setting logger opts.

ref: #203