### PR TITLE
fix: Add missing prefix to AWS return object

### DIFF
--- a/pkg/secretsmanager/secretsmanager.go
+++ b/pkg/secretsmanager/secretsmanager.go
@@ -237,8 +237,9 @@ func newAWS(config *v1alpha1.AppConfig, rClient client.Client, cloudCredNS strin
 	// secretCtx, cancel := context.WithTimeout(ctx, 40*time.Second)
 
 	return &secretManagerAWS{
-		client: client,
-		region: config.AWSRegion,
+		client:               client,
+		secretsManagerPrefix: config.SecretsManagerPrefix,
+		region:               config.AWSRegion,
 		// cancel: cancel,
 	}, nil
 }


### PR DESCRIPTION
The SecretsManagerPrefix field wasn't set in secretManagerAWS struct.

ref: CLOUD-3592