### PR TITLE
fix: add KMSKeyId option to AWS Secrets Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ testConfiguration2.yaml
 secret-agent.yaml
 secret-agent-ha.yaml
 
+# vendor
+vendor/

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Parameter | Description | Default
 `spec.appConfig.credentialsSecretName` | Name of the Kubernetes secret containing the credentials to access the cloud provider. | ""
 `spec.appConfig.gcpProjectID` | When using GCP as the secret mgr, specify the project ID.  | ""
 `spec.appConfig.awsRegion` | When using AWS  as the secret mgr, specify the region.  | ""
+`spec.appConfig.awsKmsKeyId` | When using AWS  as the secret mgr, you can specifiy the KMS Key Id else will use the default AWS managed KMS key, which poses some limitations on the secret.  | ""
 `spec.appConfig.azureVaultName` | When using Azure as the secret mgr, specify the vault name. | ""
 `spec.secrets` | List of Kubernetes secrets to create. See [Secret Config](#secret-config). | []
 

--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -189,6 +189,7 @@ type AppConfig struct {
 	CredentialsSecretName string         `json:"credentialsSecretName,omitempty"`
 	GCPProjectID          string         `json:"gcpProjectID,omitempty"`
 	AWSRegion             string         `json:"awsRegion,omitempty"`
+	AWSKmsKeyId           string         `json:"awsKmsKeyId,omitempty"`
 	AzureVaultName        string         `json:"azureVaultName,omitempty"`
 
 	// Optional timeout value to generate a individual secret. Defaults to 40

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -67,6 +67,8 @@ spec:
                 description: AppConfig is the configuration for the forgeops-secrets
                   application
                 properties:
+                  awsKmsKeyId:
+                    type: string
                   awsRegion:
                     type: string
                   azureVaultName:

--- a/pkg/secretsmanager/secretsmanager.go
+++ b/pkg/secretsmanager/secretsmanager.go
@@ -55,7 +55,7 @@ type SecretManager interface {
 	CloseClient()
 }
 
-//  secretManagerGCP container for GCP secret manager properties
+// secretManagerGCP container for GCP secret manager properties
 type secretManagerGCP struct {
 	client               *secretmanager.Client
 	secretsManagerPrefix string
@@ -68,6 +68,7 @@ type secretManagerAWS struct {
 	region               string
 	secretsManagerPrefix string
 	cancel               context.CancelFunc
+	config               v1alpha1.AppConfig
 }
 
 // secretManagerAzure container for Azure secret manager properties
@@ -240,6 +241,7 @@ func newAWS(config *v1alpha1.AppConfig, rClient client.Client, cloudCredNS strin
 		client:               client,
 		secretsManagerPrefix: config.SecretsManagerPrefix,
 		region:               config.AWSRegion,
+		config:               *config,
 		// cancel: cancel,
 	}, nil
 }
@@ -429,6 +431,9 @@ func (sm *secretManagerAWS) EnsureSecret(ctx context.Context, secretName string,
 			preExists = false
 			input := &awssecretsmanager.CreateSecretInput{
 				Name: aws.String(secretID),
+			}
+			if sm.config.AWSKmsKeyId != "" {
+				input.KmsKeyId = aws.String(sm.config.AWSKmsKeyId)
 			}
 			_, err = sm.client.CreateSecret(input)
 			if err != nil {


### PR DESCRIPTION
Adds the ability to supply own KMS key for secret creation.

Addresses #226 

@lee-baines or @jrcast you seem to be still somewhat active on this - any chance of a review on this please?