### PR TITLE
chore: Add back the EC keys as they are required by AM

### DIFF
--- a/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
+++ b/config/samples/secret-agent_v1alpha1_secretagentconfiguration.yaml
@@ -316,6 +316,15 @@ spec:
           cmd: genkeypair
           # cmd type of genkeypair takes arbritrary args to the keytool command `genkeypair`
           args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=rsajwtsigningkey,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: es256test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "256", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es256test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: es384test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "384", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es384test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
+        - name: es512test
+          cmd: genkeypair
+          args: ["-keyalg", "EC", "-keysize", "521", "-sigalg", "SHA256withECDSA", "-validity", "3650", "-dname", "CN=es512test,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]
         - name: selfserviceenctest
           cmd: genkeypair
           args: ["-keyalg", "RSA", "-keysize", "2048", "-sigalg", "SHA256WITHRSA", "-validity", "3650", "-dname", "CN=selfserviceenctest,O=ForgeRock,L=Bristol,ST=Bristol,C=UK"]


### PR DESCRIPTION
Add back the EC keys which was previously removed as they were thought to be breaking the latest image.

ref: CLOUD-4161