### PR TITLE
fix: Helm Chart Updates

### DIFF
--- a/charts/secret-agent/Chart.yaml
+++ b/charts/secret-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.2.0
+version: v1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.0"
+appVersion: "v1.2.2"

--- a/charts/secret-agent/templates/crds/secretagentconfigurations.yaml
+++ b/charts/secret-agent/templates/crds/secretagentconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: secretagentconfigurations.secret-agent.secrets.forgerock.io
 spec:
   group: secret-agent.secrets.forgerock.io
@@ -41,29 +41,44 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: SecretAgentConfiguration is the Schema for the secretagentconfigurations API
+        description: SecretAgentConfiguration is the Schema for the secretagentconfigurations
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: SecretAgentConfigurationSpec defines the desired state of SecretAgentConfiguration
+            description: SecretAgentConfigurationSpec defines the desired state of
+              SecretAgentConfiguration
             properties:
               appConfig:
-                description: AppConfig is the configuration for the forgeops-secrets application
+                description: AppConfig is the configuration for the forgeops-secrets
+                  application
                 properties:
+                  awsKmsKeyId:
+                    type: string
                   awsRegion:
                     type: string
                   azureVaultName:
                     type: string
                   backOffSecs:
                     default: 2
-                    description: Optional backoff time in seconds before retrying secret generation. Defaults to 2
+                    description: Optional backoff time in seconds before retrying
+                      secret generation. Defaults to 2
                     type: integer
                   createKubernetesObjects:
                     type: boolean
@@ -73,14 +88,17 @@ spec:
                     type: string
                   maxRetries:
                     default: 3
-                    description: Optional number of times the operator will attempt to generate secrets. Defaults to 3
+                    description: Optional number of times the operator will attempt
+                      to generate secrets. Defaults to 3
                     type: integer
                   secretTimeout:
                     default: 40
-                    description: Optional timeout value to generate a individual secret. Defaults to 40
+                    description: Optional timeout value to generate a individual secret.
+                      Defaults to 40
                     type: integer
                   secretsManager:
-                    description: SecretsManager Specifies which cloud secret manager will be used
+                    description: SecretsManager Specifies which cloud secret manager
+                      will be used
                     enum:
                     - none
                     - GCP
@@ -95,11 +113,13 @@ spec:
                 type: object
               secrets:
                 items:
-                  description: SecretConfig is the configuration for a specific Kubernetes secret
+                  description: SecretConfig is the configuration for a specific Kubernetes
+                    secret
                   properties:
                     keys:
                       items:
-                        description: KeyConfig is the configuration for a specific data key
+                        description: KeyConfig is the configuration for a specific
+                          data key
                         properties:
                           name:
                             type: string
@@ -107,13 +127,15 @@ spec:
                             description: KeySpec is the configuration for each key
                             properties:
                               algorithm:
-                                description: AlgorithmType Specifies which keystore algorithm to use
+                                description: AlgorithmType Specifies which keystore
+                                  algorithm to use
                                 enum:
                                 - ECDSAWithSHA256
                                 - SHA256WithRSA
                                 type: string
                               distinguishedName:
-                                description: DistinguishedName certificate subject data
+                                description: DistinguishedName certificate subject
+                                  data
                                 properties:
                                   commonName:
                                     type: string
@@ -156,14 +178,16 @@ spec:
                                 type: string
                               keytoolAliases:
                                 items:
-                                  description: KeytoolAliasConfig is the configuration for a keystore alias
+                                  description: KeytoolAliasConfig is the configuration
+                                    for a keystore alias
                                   properties:
                                     args:
                                       items:
                                         type: string
                                       type: array
                                     cmd:
-                                      description: KeytoolCmd Specifies the keytool command to use.
+                                      description: KeytoolCmd Specifies the keytool
+                                        command to use.
                                       enum:
                                       - genkeypair
                                       - genseckey
@@ -198,7 +222,8 @@ spec:
                               storePassPath:
                                 type: string
                               storeType:
-                                description: StoreType Specifies which keystore store type to use
+                                description: StoreType Specifies which keystore store
+                                  type to use
                                 enum:
                                 - pkcs12
                                 - jceks
@@ -214,7 +239,8 @@ spec:
                                 type: string
                             type: object
                           type:
-                            description: KeyConfigType Specifies which key type to use
+                            description: KeyConfigType Specifies which key type to
+                              use
                             enum:
                             - ca
                             - literal
@@ -243,7 +269,8 @@ spec:
             - secrets
             type: object
           status:
-            description: SecretAgentConfigurationStatus defines the observed state of SecretAgentConfiguration
+            description: SecretAgentConfigurationStatus defines the observed state
+              of SecretAgentConfiguration
             properties:
               managedKubeSecrets:
                 items:
@@ -254,7 +281,8 @@ spec:
                   type: string
                 type: array
               state:
-                description: SecretAgentConfState is used to keep track of the SAC state
+                description: SecretAgentConfState is used to keep track of the SAC
+                  state
                 type: string
               totalKubeSecrets:
                 type: integer
@@ -268,10 +296,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-

--- a/charts/secret-agent/templates/deployment.yaml
+++ b/charts/secret-agent/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "secret-agent.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -63,8 +66,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: {{ .Chart.Name }}-kube-rbac-proxy
-          image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/

--- a/charts/secret-agent/values.yaml
+++ b/charts/secret-agent/values.yaml
@@ -8,6 +8,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+kubeRbacProxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: "v0.8.0"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -26,6 +32,8 @@ rbac:
   create: true
 
 podAnnotations: {}
+
+podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
* Support overriding the kube-rbac-proxy image
* Support pod labels
* Add awsKmsKeyId which was missing in the helm template
* Update Chart version to 1.2.2
* Update docker image location
* Update CRD to match formatting in config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml