### PR TITLE
Add ability to specify uid for certificate DistinguishedNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Parameter | Description | Default
 `spec.distinguishedName.postalCode` | Used when key type is `ca` or `keyPair`. Specify the postalCode. | ""
 `spec.distinguishedName.serialNumber` | Used when key type is `ca` or `keyPair`. Specify the serialNumber. | ""
 `spec.distinguishedName.commonName` | Used when key type is `ca` or `keyPair`. Specify the commonName for the certificate. | ""
+`spec.distinguishedName.userId` | Used when key type is `ca` or `keyPair`. Specify the userId for the certificate. | ""
 `spec.truststoreImportPaths` | Used when key type is `truststore`. List of paths of certificates in the form `secretname/keyname` that will be imported into the truststore. | ""
 `spec.storeType` | Used when key type is `keytool`. Specify the keystore type. Available values: pkcs12;jceks;jks. | ""
 `spec.storePassPath` | Used when key type is `keytool`. Specify the path to the secret in the SAC to use as the keystore password in the form `secretname/keyname`. | ""

--- a/api/v1alpha1/secretagentconfiguration_types.go
+++ b/api/v1alpha1/secretagentconfiguration_types.go
@@ -94,6 +94,7 @@ type DistinguishedName struct {
 	PostalCode         []string `json:"postalCode,omitempty"`
 	SerialNumber       string   `json:"serialNumber,omitempty"`
 	CommonName         string   `json:"commonName,omitempty"`
+	UserId             string   `json:"userId,omitempty"`
 }
 
 func init() {
@@ -324,6 +325,9 @@ func (dn *DistinguishedName) isEmpty() bool {
 		return false
 	}
 	if dn.CommonName == "" {
+		return false
+	}
+	if dn.UserId == "" {
 		return false
 	}
 	return true

--- a/pkg/generator/certificate_test.go
+++ b/pkg/generator/certificate_test.go
@@ -239,4 +239,35 @@ func TestKeyPair(t *testing.T) {
 		t.Fatalf("expected no error when duration is not set %s", err)
 	}
 
+	// test uid is set when UserId is provided in dn
+	uidKey := &v1alpha1.KeyConfig{
+		Name: "myname",
+		Type: v1alpha1.KeyConfigTypeKeyPair,
+		Spec: &v1alpha1.KeySpec{
+			Duration:   &metav1.Duration{Duration: testDuration},
+			Algorithm:  v1alpha1.AlgorithmTypeSHA256WithRSA,
+			SelfSigned: true,
+			DistinguishedName: &v1alpha1.DistinguishedName{
+				UserId: "admin",
+			},
+		},
+	}
+	testKeyMgrUid, err := NewCertKeyPair(uidKey)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %+v", err)
+	}
+	err = testKeyMgrUid.Generate()
+	if err != nil {
+		t.Fatalf("Expected no error, got: %+v", err)
+	}
+
+	names := testKeyMgrUid.Cert.Cert.Subject.Names
+	oid := names[0].Type.String()
+	if "0.9.2342.19200300.100.1.1" != oid {
+		t.Fatalf("Expected 0.9.2342.19200300.100.1.1, got: %s", oid)
+	}
+	uid := names[0].Value
+	if "admin" != uid {
+		t.Fatalf("Expected admin, got: %s", uid)
+	}
 }


### PR DESCRIPTION
This can be used to generate a client certificate with a subject of `uid=admin` for use in mTLS between IDM and DS.