### PR TITLE
fix: Update openjdk version to remove vulnerabilities

### DIFF
--- a/.github/workflows/cluster_deploy.yaml
+++ b/.github/workflows/cluster_deploy.yaml
@@ -11,10 +11,10 @@ jobs:
       - name: Install Kind and Create Cluster
         run: |
           set -o errexit
-          curl -o kind -L https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
+          curl -o kind -L https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
           mkdir -p /opt/bin;
           install kind /opt/bin/
-          /opt/bin/kind create cluster --image "kindest/node:v1.25.3"
+          /opt/bin/kind create cluster --image "kindest/node:v1.30.0"
       - name: Build Secret Agent Image
         run: docker build -t controller:latest .
       - name: Load Secret Agent Image To Kind

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION="1.22.2"
 ARG GO_PACKAGE_SHA256="5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17"
 ARG KUBEBUILDER_VERSION="3.1.0"
 
-FROM openjdk:22-ea-15-jdk-slim-bullseye as tester
+FROM openjdk:23-ea-15-jdk-slim-bullseye as tester
 
 ARG GO_VERSION
 ARG GO_PACKAGE_SHA256

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifndef DEFAULT_IMG_TAG
 DEFAULT_IMG_TAG=latest
 endif
 IMG ?= controller:${DEFAULT_IMG_TAG}
+# Uncomment below for deploying to a external cluster
+# IMG=${DEFAULT_IMG_REGISTRY}/${DEFAULT_IMG_REPOSITORY}/controller:${DEFAULT_IMG_TAG}
 VERSION=$(shell echo $(IMG) | awk -F ':' '{print $$2}')
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 #CRD_OPTIONS ?= "crd:trivialVersions=false"

--- a/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
+++ b/config/crd/bases/secret-agent.secrets.forgerock.io_secretagentconfigurations.yaml
@@ -170,6 +170,8 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  userId:
+                                    type: string
                                 type: object
                               duration:
                                 type: string


### PR DESCRIPTION
Update openjdk verion to 23-ea-15-jdk-slim-bullseye to remove several high and medium vulnerabilities.

regards,
Lee