### PR TITLE
fix: Update OpenJDK version as current version is not available

### DIFF
--- a/.github/workflows/cluster_deploy.yaml
+++ b/.github/workflows/cluster_deploy.yaml
@@ -11,10 +11,10 @@ jobs:
       - name: Install Kind and Create Cluster
         run: |
           set -o errexit
-          curl -o kind -L https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          curl -o kind -L https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
           mkdir -p /opt/bin;
           install kind /opt/bin/
-          /opt/bin/kind create cluster --image "kindest/node:v1.30.0"
+          /opt/bin/kind create cluster --image "kindest/node:v1.34.0"
       - name: Build Secret Agent Image
         run: docker build -t controller:latest .
       - name: Load Secret Agent Image To Kind
@@ -45,8 +45,9 @@ jobs:
               ((COUNTER++))
               continue
           done
+          sleep 10
       - name: Deploy SecretAgentConfiguration
-        timeout-minutes: 10
+        timeout-minutes: 4
         run: |
           # make shortcut
           k=/opt/bin/kubectl
@@ -55,7 +56,6 @@ jobs:
           declare -i COUNTER=5
           until [[ $($k get sac forgerock-sac -o jsonpath='{.status.state}') == "Completed" ]];
           do
-            if (( COUNTER % 5 == 0 )); then echo "Secrets not ready yet"; fi
             ((COUNTER++))
             sleep 5
           done
@@ -65,4 +65,4 @@ jobs:
             echo "Couldn't find all the required secrets";
             exit 1
           fi
-          echo "All is well as best as we can tell."
+          echo "All secrets are successfully provisioned."

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION="1.23.9"
 ARG GO_PACKAGE_SHA256="de03e45d7a076c06baaa9618d42b3b6a0561125b87f6041c6397680a71e5bb26"
 ARG KUBEBUILDER_VERSION="3.1.0"
 
-FROM openjdk:25-jdk-slim-trixie AS tester
+FROM openjdk:26-ea-slim-trixie AS tester
 
 ARG GO_VERSION
 ARG GO_PACKAGE_SHA256
@@ -62,7 +62,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags
 
 
 
-FROM openjdk:25-jdk-slim-trixie AS release
+FROM openjdk:26-ea-slim-trixie AS release
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/charts/secret-agent/templates/deployment.yaml
+++ b/charts/secret-agent/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           command:
             - /manager
           args:
-            - --keytoolPath=/usr/local/openjdk-25/bin/keytool
+            - --keytoolPath=/usr/local/openjdk-26/bin/keytool
             - --opensslPath=/usr/bin/openssl
             - --webhook-service-ns={{ .Release.Namespace }}
             - --webhook-service-name={{ include "secret-agent.fullname" . }}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
       - command:
         - /manager
         args:
-        - --keytoolPath=/usr/local/openjdk-25/bin/keytool
+        - --keytoolPath=/usr/local/openjdk-26/bin/keytool
         - --opensslPath=/usr/bin/openssl
         - --webhook-service-ns=$(SERVICE_NAMESPACE)
         - --webhook-service-name=$(SERVICE_NAME)


### PR DESCRIPTION
Current version of OpenJDK 25 is not available hence is breaking PR builds.

ref: FORGEOPS-6198